### PR TITLE
Expand `apipass`.

### DIFF
--- a/www/login.py
+++ b/www/login.py
@@ -74,7 +74,7 @@ def load_session(include_url=True, include_header=True):
 	"""
 	# could potentially add other things here in the future...
 	session = {
-		"user": flask.session.get('user'),
+		"user": flask.session.get('user', secrets.apipass.get(flask.request.values.get("apipass"))),
 	}
 	if include_url:
 		session['url'] = flask.request.url

--- a/www/notifications.py
+++ b/www/notifications.py
@@ -53,9 +53,10 @@ def updates(conn, cur):
 	return flask.json.jsonify(notifications=get_notifications(cur, int(flask.request.values['after'])))
 
 @server.app.route('/notifications/newmessage', methods=['POST'])
+@login.with_session
 @utils.with_mysql
-def new_message(conn, cur):
-	if flask.request.values['apipass'] != secrets.apipass:
+def new_message(conn, cur, session):
+	if session["user"] != secrets.twitch_username:
 		return flask.json.jsonify(error='apipass')
 	data = {
 		'message': flask.request.values['message'],


### PR DESCRIPTION
`apipass` parameter with a recognised token is treated like a valid session
cookie. So things like `http://lrrbot.mrphlip.com/api/show/<show>` can
only be used with proper authorisation and locally testing mod-only
pages doesn't need changing `login.py`.

`apipass = "dickbutt"` in `secrets.py` needs to be replaced with
`apipass = {"dickbutt": "lrrbot"}`.
