### PR TITLE
Use Pump19 codefall code

### DIFF
--- a/common/utils.py
+++ b/common/utils.py
@@ -20,6 +20,9 @@ import werkzeug.datastructures
 from common import config
 import psycopg2
 
+import Crypto.Hash.HMAC
+import Crypto.Hash.SHA256
+import base64
 
 log = logging.getLogger('utils')
 
@@ -448,3 +451,17 @@ def strtodate(s):
 	if dt.time() != datetime.time(0):
 		dt = dt.astimezone(config.config['timezone'])
 	return dt.date()
+
+HASH_ALGORITHM = Crypto.Hash.SHA256
+def hmac_sign(message):
+	mac = Crypto.Hash.HMAC.new(
+		config.config["session_secret"].encode("utf-8"),
+		msg=message,
+		digestmod=HASH_ALGORITHM
+	)
+	return base64.urlsafe_b64encode(mac.digest() + message)
+
+def hmac_verify(signature):
+	message = base64.urlsafe_b64decode(signature)[HASH_ALGORITHM.digest_size:]
+	if hmac_sign(message) == signature:
+		return message

--- a/lrrbot/commands/__init__.py
+++ b/lrrbot/commands/__init__.py
@@ -9,3 +9,4 @@ import lrrbot.commands.static
 import lrrbot.commands.stats
 import lrrbot.commands.strawpoll
 import lrrbot.commands.quote
+import lrrbot.commands.codefall

--- a/lrrbot/commands/codefall.py
+++ b/lrrbot/commands/codefall.py
@@ -1,0 +1,47 @@
+# This code was originally part of Pump19 (https://github.com/TwistedPear-AT/pump19)
+
+# Copyright (c) 2015 Twisted Pear <pear at twistedpear dot at>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from lrrbot import bot
+from common import utils
+from common.config import config
+import random
+import irc.client
+import urllib.parse
+
+@bot.command("codefall")
+@utils.throttle()
+@utils.with_postgres
+def codefall(pg_conn, cur, lrrbot, conn, event, respond_to):
+	"""
+	Handle !codefall command.
+	If available, post a single unclaimed codefall URL.
+	"""
+	(secret_url, description, code_type) = yield from dbutils.get_codefall_entry(nick)
+
+	if not secret_url:
+		no_codefall_msg = "Could not find any unclaimed codes."
+		yield from self.client.privmsg(target, no_codefall_msg)
+		return
+
+	codefall_msg = "Codefall: {desc} ({ctype}) {url}".format(desc=description, ctype=code_type, url=secret_url)
+
+	yield from self.client.privmsg(target, codefall_msg)

--- a/webserver.py
+++ b/webserver.py
@@ -15,6 +15,7 @@ import www.botinteract
 import www.history
 import www.api
 import www.quotes
+import www.codefall
 
 app.secret_key = config["session_secret"]
 app.add_template_filter(utils.nice_duration)

--- a/www/codefall.py
+++ b/www/codefall.py
@@ -1,0 +1,149 @@
+# This code was originally part of Pump19 (https://github.com/TwistedPear-AT/pump19)
+
+# Copyright (c) 2015 Twisted Pear <pear at twistedpear dot at>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import flask
+
+from common import utils
+
+from www import server
+from www import login
+
+@server.app.route("/codefall/")
+@login.require_login
+@utils.with_postgres
+def codefall(conn, cur, session):
+	"""Show a list of all codefall pages and a form to add new ones."""
+	session = request.environ.get("beaker.session")
+	user_name = session.get("user_name")
+
+	# we can't retrieve keys without user name
+	if not user_name:
+		return template("codefall", session=session, subtitle="Codefall")
+
+	# get all codes for the user from the database
+	codes_qry = """SELECT cid, description, code, code_type, claimed
+			FROM codefall
+			WHERE user_name = :user_name"""
+	codes = db.execute(codes_qry, {"user_name": user_name})
+
+	unclaimed, claimed = list(), list()
+	for code in codes:
+		entry = {"description": code.description, "code_type": code.code_type}
+
+		if not code.claimed:
+			# for unclaimed codes we need to generate our "random" link
+			secret = int_to_codefall_key(code.cid)
+			secret_url = CODEFALL_SHOW_URL.format(secret=secret)
+			entry["secret_url"] = secret_url
+			unclaimed.append(entry)
+		else:
+			claimed.append(entry)
+
+	return template("codefall", session=session, subtitle="Codefall", unclaimed=unclaimed, claimed=claimed)
+
+
+def handle_codefall_add(db):
+	"""Add a new codefall page."""
+	session = request.environ.get("beaker.session")
+	# we require users to be logged in when adding new codes
+	if not session.get("logged_in", False):
+		redirect("/codefall")
+
+	# get all mandatory items
+	user_name = session.get("user_name")
+	description = request.forms.getunicode("description")
+	code = request.forms.getunicode("code")
+	code_type = request.forms.getunicode("code_type")
+	if not all((user_name, description, code, code_type)):
+		redirect("/codefall")
+
+	new_code_qry = """
+		INSERT INTO codefall (description, code, code_type, user_name)
+                      VALUES (:description,:code, :code_type, :user_name)"""
+	try:
+		db.execute(new_code_qry,
+			{"description": description,
+			"code": code,
+			"code_type": code_type,
+			"user_name": user_name})
+	except IntegrityError:
+		redirect("/codefall")
+
+	# everything seems fine, store the data now
+	db.commit()
+
+	# now redirect back to codefall page
+	redirect("/codefall")
+
+def handle_codefall_claim(secret, db):
+	"""Claim a codefall page."""
+	session = request.environ.get("beaker.session")
+
+	# first, try to parse the secret
+	try:
+		cid = codefall_key_to_int(secret)
+	except:
+		return template("codefall_claim", session=session, subtitle="Codefall")
+
+	claim_code_qry = """
+		UPDATE codefall
+		SET claimed = True
+		WHERE cid = :cid AND claimed = False
+		RETURNING description, code, code_type
+	"""
+
+	code = db.execute(claim_code_qry, {"cid": cid})
+	db.commit()
+	code = code.first()
+	if not code:
+		return template("codefall_claim", session=session, subtitle="Codefall")
+
+	entry = {"description": code.description, "code": code.code, "code_type": code.code_type}
+
+	return template("codefall_claim", session=session, subtitle="Codefall", entry=entry)
+
+def handle_codefall_show(secret, db):
+	"""Show a codefall page (letting people claim it)."""
+	session = request.environ.get("beaker.session")
+
+	# first, try to parse the secret
+	try:
+		cid = codefall_key_to_int(secret)
+	except:
+		return template("codefall_show", session=session, subtitle="Codefall")
+
+	show_code_qry = """
+		SELECT description, code_type
+		FROM codefall
+		WHERE cid = :cid AND claimed = False
+	"""
+
+	code = db.execute(show_code_qry, {"cid": cid})
+	code = code.first()
+	if not code:
+		return template("codefall_show", session=session, subtitle="Codefall")
+
+	claim_url = CODEFALL_CLAIM_URL.format(secret=secret)
+
+	entry = {"description": code.description, "claim_url": claim_url, "code_type": code.code_type}
+
+	return template("codefall_show", session=session, subtitle="Codefall", entry=entry)

--- a/www/codefall.py
+++ b/www/codefall.py
@@ -32,118 +32,99 @@ from www import login
 @utils.with_postgres
 def codefall(conn, cur, session):
 	"""Show a list of all codefall pages and a form to add new ones."""
-	session = request.environ.get("beaker.session")
-	user_name = session.get("user_name")
-
-	# we can't retrieve keys without user name
-	if not user_name:
-		return template("codefall", session=session, subtitle="Codefall")
 
 	# get all codes for the user from the database
-	codes_qry = """SELECT cid, description, code, code_type, claimed
-			FROM codefall
-			WHERE user_name = :user_name"""
-	codes = db.execute(codes_qry, {"user_name": user_name})
-
+	cur.execute("""
+		SELECT cid, description, code, code_type, claimed
+		FROM codefall
+		WHERE user_name = %s
+	""", (session["user"],))
+	print(session["user"])
 	unclaimed, claimed = list(), list()
-	for code in codes:
-		entry = {"description": code.description, "code_type": code.code_type}
+	for cid, description, code, code_type, is_claimed in cur:
+		entry = {"description": description, "code_type": code_type}
 
-		if not code.claimed:
+		if not is_claimed:
 			# for unclaimed codes we need to generate our "random" link
-			secret = int_to_codefall_key(code.cid)
-			secret_url = CODEFALL_SHOW_URL.format(secret=secret)
-			entry["secret_url"] = secret_url
+			cid = utils.hmac_sign(str(cid).encode("utf-8")).decode("utf-8")
+			entry["url"] = flask.url_for("codefall_show", code=cid, _external=True)
 			unclaimed.append(entry)
 		else:
 			claimed.append(entry)
 
-	return template("codefall", session=session, subtitle="Codefall", unclaimed=unclaimed, claimed=claimed)
+	return flask.render_template("codefall.html", session=session, unclaimed=unclaimed, claimed=claimed)
 
-
-def handle_codefall_add(db):
-	"""Add a new codefall page."""
-	session = request.environ.get("beaker.session")
-	# we require users to be logged in when adding new codes
-	if not session.get("logged_in", False):
-		redirect("/codefall")
-
-	# get all mandatory items
-	user_name = session.get("user_name")
-	description = request.forms.getunicode("description")
-	code = request.forms.getunicode("code")
-	code_type = request.forms.getunicode("code_type")
-	if not all((user_name, description, code, code_type)):
-		redirect("/codefall")
-
-	new_code_qry = """
+@server.app.route("/codefall/add", methods=["POST"])
+@login.require_login
+@utils.with_postgres
+def codefall_add(conn, cur, session):
+	cur.execute("""
 		INSERT INTO codefall (description, code, code_type, user_name)
-                      VALUES (:description,:code, :code_type, :user_name)"""
-	try:
-		db.execute(new_code_qry,
-			{"description": description,
-			"code": code,
-			"code_type": code_type,
-			"user_name": user_name})
-	except IntegrityError:
-		redirect("/codefall")
+		VALUES (%s, %s, %s, %s)
+	""", (
+		flask.request.values["description"],
+		flask.request.values["code"],
+		flask.request.values["code_type"],
+		session["user"]
+	))
 
-	# everything seems fine, store the data now
-	db.commit()
+	return flask.redirect(flask.url_for("codefall"))
 
-	# now redirect back to codefall page
-	redirect("/codefall")
-
-def handle_codefall_claim(secret, db):
+@server.app.route("/codefall/claim/<code>")
+@login.require_login
+@utils.with_postgres
+def codefall_claim(conn, cur, session, code):
 	"""Claim a codefall page."""
-	session = request.environ.get("beaker.session")
 
 	# first, try to parse the secret
-	try:
-		cid = codefall_key_to_int(secret)
-	except:
-		return template("codefall_claim", session=session, subtitle="Codefall")
+	cid = utils.hmac_verify(code.encode("utf-8"))
+	if cid is None:
+		return utils.error("Invalid codefall code")
+	cid = int(cid)
 
-	claim_code_qry = """
+	cur.execute("""
 		UPDATE codefall
-		SET claimed = True
-		WHERE cid = :cid AND claimed = False
-		RETURNING description, code, code_type
-	"""
-
-	code = db.execute(claim_code_qry, {"cid": cid})
-	db.commit()
-	code = code.first()
-	if not code:
-		return template("codefall_claim", session=session, subtitle="Codefall")
-
-	entry = {"description": code.description, "code": code.code, "code_type": code.code_type}
-
-	return template("codefall_claim", session=session, subtitle="Codefall", entry=entry)
-
-def handle_codefall_show(secret, db):
-	"""Show a codefall page (letting people claim it)."""
-	session = request.environ.get("beaker.session")
-
-	# first, try to parse the secret
-	try:
-		cid = codefall_key_to_int(secret)
-	except:
-		return template("codefall_show", session=session, subtitle="Codefall")
-
-	show_code_qry = """
-		SELECT description, code_type
+		SET claimed = TRUE
+		WHERE cid = %s AND NOT claimed
+	""", (cid, ))
+	claimed = cur.rowcount == 0
+	cur.execute("""
+		SELECT description, code, code_type
 		FROM codefall
-		WHERE cid = :cid AND claimed = False
-	"""
+		WHERE cid = %s
+	""", (cid, ))
 
-	code = db.execute(show_code_qry, {"cid": cid})
-	code = code.first()
-	if not code:
-		return template("codefall_show", session=session, subtitle="Codefall")
+	for description, code, code_type in cur:
+		return flask.render_template("codefall_claim.html",
+			session=session,
+			description=description,
+			code=code,
+			code_type=code_type,
+			claimed=claimed
+		)
 
-	claim_url = CODEFALL_CLAIM_URL.format(secret=secret)
+@server.app.route("/codefall/<code>")
+@login.require_login
+@utils.with_postgres
+def codefall_show(conn, cur, session, code):
+	"""Show a codefall page (letting people claim it)."""
+	# first, try to parse the secret
+	cid = utils.hmac_verify(code.encode("utf-8"))
+	if cid is None:
+		return utils.error_page("Invalid codefall code")
+	cid = int(cid)
 
-	entry = {"description": code.description, "claim_url": claim_url, "code_type": code.code_type}
+	cur.execute("""
+		SELECT description, code_type, claimed
+		FROM codefall
+		WHERE cid = %s AND NOT claimed
+	""", (cid, ))
 
-	return template("codefall_show", session=session, subtitle="Codefall", entry=entry)
+	for description, code_type, claimed in cur:
+		url = flask.url_for("codefall_claim", code=code)
+		return flask.render_template("codefall_show.html", session=session,
+			       description=description,
+			       code_type=code_type,
+			       url=url,
+			       claimed=claimed,
+		)

--- a/www/templates/codefall.html
+++ b/www/templates/codefall.html
@@ -1,0 +1,81 @@
+{%extends "master.html"%}
+{%block title%}Codefall{%endblock%}
+{%block header%}Codefall{%endblock%}
+{%block headextra%}
+<style>
+form {
+	display: table;
+}
+
+form div {
+	display: table-row;
+}
+
+form div label, form div span {
+	display: table-cell;
+	padding: 0.25ex 0.5ex;
+}
+
+form div span {
+	text-align: center;
+}
+
+form div label {
+	text-align: right;
+	font-weight: bold;
+}
+
+</style>
+{%endblock%}
+{%block content%}
+<h2>Unclaimed entries</h2>
+<table class="nicetable">
+	<thead><tr><th>Description</th><th>Type</th><th>URL</th></tr></thead>
+	{% for entry in unclaimed %}
+		<tr>
+			<td>{{ entry["description"] }}</td>
+			<td>{{ entry["code_type"] }}</td>
+			<td><a href="{{ entry["url"] }}"><code>{{ entry["url"] }}</code></a></td>
+		</tr>
+	{% endfor %}
+	<tbody>
+	</tbody>
+</table>
+
+<h2>Add a new entry</h2>
+<form action="{{ url_for("codefall_add") }}" method="POST">
+	<input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
+	<div>
+		<label for="description">Description:</label>
+		<span><input type="text" name="description" size="40" required></span>
+	</div>
+	<div>
+		<label for="code">Link or key:</label>
+		<span><input type="text" name="code" size="40" required></span>
+	</div>
+	<div>
+		<label for="code_type">Type:</label>
+		<span><select name="code_type">
+			<option>Humble Bundle</option>
+			<option>Steam</option>
+			<option>GOG</option>
+			<option>Desura</option>
+			<option>Other</option>
+		</select></span>
+	</div>
+	<div><span><input type="reset"></span><span><input type="submit"></span></div>
+</form>
+
+<h2>Claimed entries</h2>
+<table class="nicetable">
+	<thead><tr><th>Description</th><th>Type</th></tr></thead>
+	{% for entry in claimed %}
+		<tr>
+			<td>{{ entry["description"] }}</td>
+			<td>{{ entry["code_type"] }}</td>
+		</tr>
+	{% endfor %}
+	<tbody>
+	</tbody>
+</table>
+{%endblock%}

--- a/www/templates/codefall_claim.html
+++ b/www/templates/codefall_claim.html
@@ -1,0 +1,11 @@
+{%extends "master.html"%}
+{%block title%}Codefall{%endblock%}
+{%block header%}Codefall{%endblock%}
+{%block content%}
+<h2>{{ description }} ({{ code_type }})</h2>
+{% if claimed %}
+	<p>Code already claimed.</p>
+{% else %}
+	<p>Your code: <code>{{ code | urlize }}</code></p>
+{% endif %}
+{%endblock%}

--- a/www/templates/codefall_show.html
+++ b/www/templates/codefall_show.html
@@ -1,0 +1,11 @@
+{%extends "master.html"%}
+{%block title%}Codefall{%endblock%}
+{%block header%}Codefall{%endblock%}
+{%block content%}
+<h2>{{ description }} ({{ code_type }})</h2>
+{% if claimed %}
+	<p>Code already claimed.</p>
+{% else %}
+	<p><a href="{{ url }}">Claim code</a></p>
+{% endif %}
+{%endblock%}

--- a/www/templates/master.html
+++ b/www/templates/master.html
@@ -53,6 +53,7 @@
 	<li><a href="{{url_for('archive')|e}}">Past Broadcasts</a></li>
 	<li><a href="{{url_for('archive')|e}}?highlights=true">Highlights</a></li>
 	<li><a href="{{url_for('quotes')|e}}">Quotes</a></li>
+	<li><a href="{{url_for('codefall')|e}}">Codefall</a></li>
 	{%if session['header']['is_mod']%}
 	<li><a href="{{url_for('commands')|e}}">Responses</a></li>
 	<li><a href="{{url_for('commands')|e}}?mode=explanations">Explanations</a></li>

--- a/wwwsql/codefall.tbl
+++ b/wwwsql/codefall.tbl
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS codefall (
+    cid SERIAL PRIMARY KEY,
+    description TEXT NOT NULL,
+    code TEXT NOT NULL,
+    code_type TEXT NOT NULL,
+    user_name TEXT NOT NULL,
+    claimed BOOLEAN NOT NULL DEFAULT FALSE
+);


### PR DESCRIPTION
Differences with Pump19:
* Replaced [RC2](https://en.wikipedia.org/wiki/RC2) with HMAC-SHA256. I assumed it was used to obfuscate the code IDs so someone couldn't enumerate all available codes and claim them. The correct way is to require that all requests are signed.
* Awful web interface. I can't HTML or CSS.

CC: @TwistedPear-AT
Closes #17.