### PR TITLE
Twitch chat protocol upgrades

### DIFF
--- a/common/config.py
+++ b/common/config.py
@@ -55,8 +55,6 @@ if config['logfile'] == "":
 
 # notifyuser - user to watch for notifications
 config['notifyuser'] = config.get('notifyuser', 'twitchnotify').lower()
-# metadatauser - user to watch for Twitch metadata
-config['metadatauser'] = config.get('metadatauser', 'jtv').lower()
 # commandprefix - symbol to prefix all bot commands
 config.setdefault('commandprefix', '!')
 # siteurl - root of web site

--- a/lrrbot/__init__.py
+++ b/lrrbot/__init__.py
@@ -170,7 +170,7 @@ class LRRBot(irc.bot.SingleServerIRCBot):
 	def on_connect(self, conn, event):
 		"""On connecting to the server, join our target channel"""
 		log.info("Connected to server")
-		conn.cap("REQ", "twitch.tv/membership") # get join/part messages
+		#conn.cap("REQ", "twitch.tv/membership") # get join/part messages
 		conn.cap("REQ", "twitch.tv/tags") # get metadata tags
 		conn.cap("REQ", "twitch.tv/commands") # get special commands
 		conn.join("#%s" % config['channel'])
@@ -212,7 +212,7 @@ class LRRBot(irc.bot.SingleServerIRCBot):
 		if int(tags.get('subscriber', 0)):
 			metadata['specialuser'].add('subscriber')
 		if int(tags.get('turbo', 0)):
-			metadata['specialuser'].add('subscriber')
+			metadata['specialuser'].add('turbo')
 		if tags.get('user-type'):
 			metadata['specialuser'].add(tags.get('user-type'))
 		if self.is_mod(event):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-irc>=11.0.1
+irc>=12.2
 python-dateutil>=2.2
 flask>=0.10.1
 pycrypto>=2.6.0

--- a/wwwsql/log.tbl
+++ b/wwwsql/log.tbl
@@ -7,6 +7,8 @@ CREATE TABLE log (
     messagehtml TEXT COLLATE "en_US.utf8" NOT NULL,
     specialuser TEXT[] COLLATE "en_US.utf8",
     usercolor TEXT COLLATE "en_US.utf8",
-    emoteset INTEGER[]
+    emoteset INTEGER[],
+    emotes TEXT,
+    displayname TEXT
 );
 CREATE INDEX log_idx1 ON log(time);


### PR DESCRIPTION
* Up IRC library version to include handling for IRCv3 tags
* Send CAP REQ messages on connect
* Get message metadata from IRCv3 tags instead of from "jtv" user
 * NB: still getting notifications from "twitchnotify" user, that doesn't seem to have changed
* Update chatlog to use the new way of getting the emotes
 * NB: still using the old way of generating the emotes for *outgoing* messages