### PR TITLE
Handle Twitch whispers

### DIFF
--- a/common/config.py
+++ b/common/config.py
@@ -87,3 +87,7 @@ config.setdefault('twitch_clientsecret', '')
 
 # session_secret - Secret key for signing session cookies
 config.setdefault('session_secret', '')
+
+# whispers - boolean option, whether to connect to group chat server and respond to whispers
+config.setdefault('whispers', False)
+config['whispers'] = str(config['whispers']).lower() != 'false'

--- a/common/utils.py
+++ b/common/utils.py
@@ -113,17 +113,11 @@ def coro_decorator(decorator):
 	@functools.wraps(decorator)
 	def wrapper(func):
 		is_coro = asyncio.iscoroutinefunction(func)
-		if is_coro:
-			coro_func = func
-		else:
-			# create a coroutine function that never yields and returns the same value
-			@asyncio.coroutine
-			@functools.wraps(func)
-			def coro_func(*args, **kwargs):
-				yield from []
-				return func(*args, **kwargs)
+		if not is_coro:
+			func = asyncio.coroutine(func)
 
-		decorated_coro = decorator(coro_func)
+		decorated_coro = decorator(func)
+		assert asyncio.iscoroutinefunction(decorated_coro)
 
 		if is_coro:
 			return decorated_coro

--- a/common/utils.py
+++ b/common/utils.py
@@ -252,7 +252,7 @@ class twitch_throttle:
 		return wrapper
 
 def public_only(func):
-	"""Prevent an event-handler function form being called via private message
+	"""Prevent an event-handler function from being called via private message
 
 	Usage:
 	@public_only

--- a/common/utils.py
+++ b/common/utils.py
@@ -496,13 +496,15 @@ def immutable(obj):
 		return obj
 
 
+def get_postgres():
+	return psycopg2.connect(config.config["postgres"])
+
 def with_postgres(func):
 	"""Decorator to pass a PostgreSQL connection and cursor to a function"""
 	@functools.wraps(func)
 	def wrapper(*args, **kwargs):
-		with psycopg2.connect(config.config["postgres"]) as conn:
-			with conn.cursor() as cur:
-				return func(conn, cur, *args, **kwargs)
+		with get_postgres() as conn, conn.cursor() as cur:
+			return func(conn, cur, *args, **kwargs)
 	return wrapper
 
 

--- a/common/utils.py
+++ b/common/utils.py
@@ -303,6 +303,22 @@ def swallow_errors(func):
 	def wrapper(*args, **kwargs):
 		try:
 			return func(*args, **kwargs)
+		except (KeyboardInterrupt, SystemExit):
+			raise
+		except:
+			log.exception("Exception in " + func.__name__)
+			return None
+	return wrapper
+
+def swallow_errors_coro(func):
+	"""Log and absorb any errors thrown by a function"""
+	@asyncio.coroutine
+	@functools.wraps(func)
+	def wrapper(*args, **kwargs):
+		try:
+			return (yield from func(*args, **kwargs))
+		except (KeyboardInterrupt, SystemExit, asyncio.CancelledError):
+			raise
 		except:
 			log.exception("Exception in " + func.__name__)
 			return None

--- a/common/utils.py
+++ b/common/utils.py
@@ -77,6 +77,10 @@ shorten = getattr(textwrap, "shorten", shorten_fallback)
 
 DEFAULT_THROTTLE = 15
 
+SILENT = 0
+PRIVATE = 1
+PUBLIC = 2
+
 class throttle(object):
 	"""Prevent a function from being called more often than once per period
 
@@ -85,7 +89,7 @@ class throttle(object):
 	def func(...):
 		...
 
-	@throttle([period], notify=True, modoverride=True)
+	@throttle([period], notify=PUBLIC, modoverride=True)
 	def func(lrrbot, conn, event, ...):
 		...
 
@@ -101,7 +105,7 @@ class throttle(object):
 	count allows the function to be called a given number of times during the period,
 	but no more.
 	"""
-	def __init__(self, period=DEFAULT_THROTTLE, notify=False, modoverride=False, params=[], log=True, count=1):
+	def __init__(self, period=DEFAULT_THROTTLE, notify=SILENT, modoverride=False, params=[], log=True, count=1):
 		self.period = period
 		self.notify = notify
 		self.modoverride = modoverride
@@ -145,7 +149,7 @@ class throttle(object):
 					conn = args[1]
 					event = args[2]
 					source = irc.client.NickMask(event.source)
-					if irc.client.is_channel(event.target):
+					if irc.client.is_channel(event.target) and self.notify == PUBLIC:
 						respond_to = event.target
 					else:
 						respond_to = source.nick

--- a/lrrbot/__init__.py
+++ b/lrrbot/__init__.py
@@ -391,7 +391,7 @@ class LRRBot(irc.bot.SingleServerIRCBot):
 		else:
 			return storage.find_game(show, self.get_current_game_real(), readonly)
 
-	@utils.throttle(GAME_CHECK_INTERVAL, log=False)
+	@utils.cache(GAME_CHECK_INTERVAL)
 	def get_current_game_real(self):
 		return twitch.get_game_playing()
 

--- a/lrrbot/__init__.py
+++ b/lrrbot/__init__.py
@@ -94,8 +94,6 @@ class LRRBot(irc.bot.SingleServerIRCBot):
 		self.subs = set(storage.data.get('subs', []))
 		self.autostatus = set(storage.data.get('autostatus', []))
 
-		self.jointime = 0
-
 	def start(self):
 		# Let us run on windows, without the socket
 		if hasattr(socket, 'AF_UNIX'):
@@ -191,28 +189,19 @@ class LRRBot(irc.bot.SingleServerIRCBot):
 	def on_connect(self, conn, event):
 		"""On connecting to the server, join our target channel"""
 		log.info("Connected to server")
-		conn.cap("REQ", "twitch.tv/membership") # get join/part messages
 		conn.cap("REQ", "twitch.tv/tags") # get metadata tags
 		conn.cap("REQ", "twitch.tv/commands") # get special commands
 		conn.join("#%s" % config['channel'])
-		self.jointime = time.time()
+		conn.cap("REQ", "twitch.tv/membership") # get join/part messages - after we join, so we don't get a flood of them when we arrive
 		self.check_privmsg_wrapper(conn)
 
 	def on_channel_join(self, conn, event):
 		source = irc.client.NickMask(event.source)
 		if (source.nick.lower() == config['username'].lower()):
 			log.info("Channel %s joined" % event.target)
-			return
-
-		# When we join a channel, Twitch sends a list of who's in the channel as a
-		# batch of join messages, as much as a minute afterward...
-		# So we need to ignore joins that are received shortly after we join the
-		# channel, as they're probably not really people who just joined ... no need
-		# to spam everyone in the channel just cause we restarted the bot.
-		if time.time() - self.jointime > 75:
-			if source.nick.lower() in self.autostatus:
-				from lrrbot.commands.misc import send_status
-				send_status(self, conn, source.nick)
+		elif source.nick.lower() in self.autostatus:
+			from lrrbot.commands.misc import send_status
+			send_status(self, conn, source.nick)
 
 	@utils.swallow_errors
 	def do_keepalive(self):

--- a/lrrbot/asyncreactor.py
+++ b/lrrbot/asyncreactor.py
@@ -1,0 +1,19 @@
+import asyncio
+import irc.client
+
+class AsyncReactor(irc.client.Reactor):
+	def __init__(self, loop):
+		self.loop = loop
+		super().__init__(self.on_connect, self.on_disconnect, self.on_schedule)
+
+	def on_connect(self, socket):
+		self.loop.add_reader(socket, self.process_data, [socket])
+
+	def on_disconnect(self, socket):
+		self.loop.remove_reader(socket)
+
+	def on_schedule(self, delay):
+		self.loop.call_later(delay, self.process_timeout)
+
+	def process_forever(self):
+		raise NotImplementedError

--- a/lrrbot/chatlog.py
+++ b/lrrbot/chatlog.py
@@ -53,7 +53,7 @@ def stop_task():
 	queue.put_nowait(("exit", ()))
 
 
-@utils.swallow_errors_coro
+@utils.swallow_errors
 @asyncio.coroutine
 def do_log_chat(time, event, metadata):
 	"""
@@ -80,7 +80,7 @@ def do_log_chat(time, event, metadata):
 			html,
 		))
 
-@utils.swallow_errors_coro
+@utils.swallow_errors
 @asyncio.coroutine
 def do_clear_chat_log(time, nick):
 	"""
@@ -106,7 +106,7 @@ def do_clear_chat_log(time, nick):
 				key,
 			))
 
-@utils.swallow_errors_coro
+@utils.swallow_errors
 @asyncio.coroutine
 def do_rebuild_all():
 	"""
@@ -232,7 +232,7 @@ def build_message_html(time, source, target, message, specialuser, usercolor, em
 	ret.append('</div>')
 	return ''.join(ret)
 
-@utils.cache(CACHE_EXPIRY, params=[0], coro=True)
+@utils.cache(CACHE_EXPIRY, params=[0])
 @asyncio.coroutine
 def get_display_name(nick):
 	try:
@@ -243,7 +243,7 @@ def get_display_name(nick):
 		return nick
 
 re_just_words = re.compile("^\w+$")
-@utils.cache(CACHE_EXPIRY, coro=True)
+@utils.cache(CACHE_EXPIRY)
 @asyncio.coroutine
 def get_twitch_emotes():
 	data = yield from utils.http_request_coro("https://api.twitch.tv/kraken/chat/emoticons")
@@ -265,7 +265,7 @@ def get_twitch_emotes():
 			}
 	return emotesets
 
-@utils.cache(CACHE_EXPIRY, coro=True)
+@utils.cache(CACHE_EXPIRY)
 @asyncio.coroutine
 def get_twitch_emotes_undocumented():
 	# This endpoint is not documented, however `/chat/emoticons` might be deprecated soon.

--- a/lrrbot/chatlog.py
+++ b/lrrbot/chatlog.py
@@ -232,7 +232,7 @@ def build_message_html(time, source, target, message, specialuser, usercolor, em
 	ret.append('</div>')
 	return ''.join(ret)
 
-@utils.throttle(CACHE_EXPIRY, params=[0], log=False)
+@utils.cache(CACHE_EXPIRY, params=[0])
 def get_display_name(nick):
 	try:
 		data = utils.http_request("https://api.twitch.tv/kraken/users/%s" % nick)
@@ -242,7 +242,7 @@ def get_display_name(nick):
 		return nick
 
 re_just_words = re.compile("^\w+$")
-@utils.throttle(CACHE_EXPIRY, log=False)
+@utils.cache(CACHE_EXPIRY)
 def get_twitch_emotes():
 	data = utils.http_request("https://api.twitch.tv/kraken/chat/emoticons")
 	data = json.loads(data)['emoticons']
@@ -263,7 +263,7 @@ def get_twitch_emotes():
 			}
 	return emotesets
 
-@utils.throttle(CACHE_EXPIRY, log=False)
+@utils.cache(CACHE_EXPIRY)
 def get_twitch_emotes_undocumented():
 	# This endpoint is not documented, however `/chat/emoticons` might be deprecated soon.
 	data = utils.http_request("https://api.twitch.tv/kraken/chat/emoticon_images")

--- a/lrrbot/commands/card.py
+++ b/lrrbot/commands/card.py
@@ -13,7 +13,7 @@ with open("mtgcards.json") as fp:
 	CARD_DATA = json.load(fp)
 
 @bot.command("card (.+)")
-@utils.throttle(60, count=3, notify=utils.Visibility.PRIVATE, modoverride=True, allowprivate=True)
+@utils.throttle(60, count=3)
 def card_lookup(lrrbot, conn, event, respond_to, search):
 	"""
 	Command: !card card-name

--- a/lrrbot/commands/card.py
+++ b/lrrbot/commands/card.py
@@ -13,7 +13,7 @@ with open("mtgcards.json") as fp:
 	CARD_DATA = json.load(fp)
 
 @bot.command("card (.+)")
-@utils.throttle(60, count=3, notify=utils.PRIVATE, modoverride=True)
+@utils.throttle(60, count=3, notify=utils.PRIVATE, modoverride=True, allowprivate=True)
 def card_lookup(lrrbot, conn, event, respond_to, search):
 	"""
 	Command: !card card-name

--- a/lrrbot/commands/card.py
+++ b/lrrbot/commands/card.py
@@ -13,7 +13,7 @@ with open("mtgcards.json") as fp:
 	CARD_DATA = json.load(fp)
 
 @bot.command("card (.+)")
-@utils.throttle(60, count=3, modoverride=True)
+@utils.throttle(60, count=3, notify=utils.PRIVATE, modoverride=True)
 def card_lookup(lrrbot, conn, event, respond_to, search):
 	"""
 	Command: !card card-name

--- a/lrrbot/commands/card.py
+++ b/lrrbot/commands/card.py
@@ -13,7 +13,7 @@ with open("mtgcards.json") as fp:
 	CARD_DATA = json.load(fp)
 
 @bot.command("card (.+)")
-@utils.throttle(60, count=3, notify=utils.PRIVATE, modoverride=True, allowprivate=True)
+@utils.throttle(60, count=3, notify=utils.Visibility.PRIVATE, modoverride=True, allowprivate=True)
 def card_lookup(lrrbot, conn, event, respond_to, search):
 	"""
 	Command: !card card-name

--- a/lrrbot/commands/explain.py
+++ b/lrrbot/commands/explain.py
@@ -5,7 +5,7 @@ from lrrbot import bot, log, storage
 
 
 @bot.command("explain (.*?)")
-@utils.throttle(30, params=[4], count=2, notify=utils.PRIVATE, modoverride=True, allowprivate=True)
+@utils.throttle(30, params=[4], count=2, notify=utils.Visibility.PRIVATE, modoverride=True, allowprivate=True)
 def explain_response(lrrbot, conn, event, respond_to, command):
 	"""
 	Command: !explain TOPIC

--- a/lrrbot/commands/explain.py
+++ b/lrrbot/commands/explain.py
@@ -5,7 +5,7 @@ from lrrbot import bot, log, storage
 
 
 @bot.command("explain (.*?)")
-@utils.throttle(30, params=[4], count=2, notify=utils.Visibility.PRIVATE, modoverride=True, allowprivate=True)
+@utils.throttle(30, params=[4], count=2)
 def explain_response(lrrbot, conn, event, respond_to, command):
 	"""
 	Command: !explain TOPIC

--- a/lrrbot/commands/explain.py
+++ b/lrrbot/commands/explain.py
@@ -5,7 +5,7 @@ from lrrbot import bot, log, storage
 
 
 @bot.command("explain (.*?)")
-@utils.throttle(30, params=[4], count=2, modoverride=True)
+@utils.throttle(30, params=[4], count=2, notify=utils.PRIVATE, modoverride=True)
 def explain_response(lrrbot, conn, event, respond_to, command):
 	"""
 	Command: !explain TOPIC

--- a/lrrbot/commands/explain.py
+++ b/lrrbot/commands/explain.py
@@ -5,7 +5,7 @@ from lrrbot import bot, log, storage
 
 
 @bot.command("explain (.*?)")
-@utils.throttle(30, params=[4], count=2, notify=utils.PRIVATE, modoverride=True)
+@utils.throttle(30, params=[4], count=2, notify=utils.PRIVATE, modoverride=True, allowprivate=True)
 def explain_response(lrrbot, conn, event, respond_to, command):
 	"""
 	Command: !explain TOPIC

--- a/lrrbot/commands/game.py
+++ b/lrrbot/commands/game.py
@@ -9,7 +9,7 @@ def game_name(game):
 	return game.get("display", game["name"])
 
 @bot.command("game")
-@utils.throttle(notify=utils.PRIVATE, allowprivate=True)
+@utils.throttle(notify=utils.Visibility.PRIVATE, allowprivate=True)
 def current_game(lrrbot, conn, event, respond_to):
 	"""
 	Command: !game
@@ -130,7 +130,7 @@ def refresh(lrrbot, conn, event, respond_to):
 
 @bot.command("game completed")
 @utils.mod_only
-@utils.throttle(30, notify=utils.PUBLIC)
+@utils.throttle(30, notify=utils.Visibility.PUBLIC)
 def completed(lrrbot, conn, event, respond_to):
 	"""
 	Command: !game completed

--- a/lrrbot/commands/game.py
+++ b/lrrbot/commands/game.py
@@ -9,7 +9,7 @@ def game_name(game):
 	return game.get("display", game["name"])
 
 @bot.command("game")
-@utils.throttle(notify=utils.Visibility.PRIVATE, allowprivate=True)
+@utils.throttle()
 def current_game(lrrbot, conn, event, respond_to):
 	"""
 	Command: !game
@@ -52,7 +52,7 @@ def vote(lrrbot, conn, event, respond_to, vote_good, vote_bad):
 	lrrbot.vote_update = respond_to, game
 	vote_respond(lrrbot, conn, respond_to, game)
 
-@utils.throttle(60, log=False)
+@utils.cache(60)
 def vote_respond(lrrbot, conn, respond_to, game):
 	if game and game.get("votes"):
 		good = sum(game["votes"].values())
@@ -130,7 +130,7 @@ def refresh(lrrbot, conn, event, respond_to):
 
 @bot.command("game completed")
 @utils.mod_only
-@utils.throttle(30, notify=utils.Visibility.PUBLIC)
+@utils.throttle(30, notify=utils.Visibility.PUBLIC, modoverride=False, allowprivate=False)
 def completed(lrrbot, conn, event, respond_to):
 	"""
 	Command: !game completed

--- a/lrrbot/commands/game.py
+++ b/lrrbot/commands/game.py
@@ -9,7 +9,7 @@ def game_name(game):
 	return game.get("display", game["name"])
 
 @bot.command("game")
-@utils.throttle(notify=utils.PRIVATE)
+@utils.throttle(notify=utils.PRIVATE, allowprivate=True)
 def current_game(lrrbot, conn, event, respond_to):
 	"""
 	Command: !game

--- a/lrrbot/commands/game.py
+++ b/lrrbot/commands/game.py
@@ -9,7 +9,7 @@ def game_name(game):
 	return game.get("display", game["name"])
 
 @bot.command("game")
-@utils.throttle()
+@utils.throttle(notify=utils.PRIVATE)
 def current_game(lrrbot, conn, event, respond_to):
 	"""
 	Command: !game
@@ -130,7 +130,7 @@ def refresh(lrrbot, conn, event, respond_to):
 
 @bot.command("game completed")
 @utils.mod_only
-@utils.throttle(30, notify=True)
+@utils.throttle(30, notify=utils.PUBLIC)
 def completed(lrrbot, conn, event, respond_to):
 	"""
 	Command: !game completed

--- a/lrrbot/commands/highlights.py
+++ b/lrrbot/commands/highlights.py
@@ -7,6 +7,7 @@ from lrrbot import bot, storage, twitch
 
 
 @bot.command("highlight (.*?)")
+@utils.public_only
 @utils.sub_only
 @utils.throttle(60, notify=utils.PUBLIC)
 def highlight(lrrbot, conn, event, respond_to, description):

--- a/lrrbot/commands/highlights.py
+++ b/lrrbot/commands/highlights.py
@@ -9,7 +9,7 @@ from lrrbot import bot, storage, twitch
 @bot.command("highlight (.*?)")
 @utils.public_only
 @utils.sub_only
-@utils.throttle(60, notify=utils.Visibility.PUBLIC)
+@utils.throttle(60, notify=utils.Visibility.PUBLIC, modoverride=False, allowprivate=False)
 def highlight(lrrbot, conn, event, respond_to, description):
 	"""
 	Command: !highlight DESCRIPTION

--- a/lrrbot/commands/highlights.py
+++ b/lrrbot/commands/highlights.py
@@ -9,7 +9,7 @@ from lrrbot import bot, storage, twitch
 @bot.command("highlight (.*?)")
 @utils.public_only
 @utils.sub_only
-@utils.throttle(60, notify=utils.PUBLIC)
+@utils.throttle(60, notify=utils.Visibility.PUBLIC)
 def highlight(lrrbot, conn, event, respond_to, description):
 	"""
 	Command: !highlight DESCRIPTION

--- a/lrrbot/commands/highlights.py
+++ b/lrrbot/commands/highlights.py
@@ -8,7 +8,7 @@ from lrrbot import bot, storage, twitch
 
 @bot.command("highlight (.*?)")
 @utils.sub_only
-@utils.throttle(60)
+@utils.throttle(60, notify=utils.PUBLIC)
 def highlight(lrrbot, conn, event, respond_to, description):
 	"""
 	Command: !highlight DESCRIPTION

--- a/lrrbot/commands/misc.py
+++ b/lrrbot/commands/misc.py
@@ -17,7 +17,7 @@ def test(lrrbot, conn, event, respond_to):
 	conn.privmsg(respond_to, "Test")
 
 @bot.command("storm(?:count)?")
-@utils.throttle(notify=utils.PRIVATE)
+@utils.throttle(notify=utils.PRIVATE, allowprivate=True)
 def stormcount(lrrbot, conn, event, respond_to):
 	"""
 	Command: !storm
@@ -36,7 +36,7 @@ def stormcount(lrrbot, conn, event, respond_to):
 	conn.privmsg(respond_to, "Today's storm count: %d" % storage.data["storm"]["count"])
 	
 @bot.command("spam(?:count)?")
-@utils.throttle(notify=utils.PRIVATE)
+@utils.throttle(notify=utils.PRIVATE, allowprivate=True)
 def spamcount(lrrbot, conn, event, respond_to):
 	"""
 	Command: !spam
@@ -60,7 +60,7 @@ DESERTBUS_START = datetime.datetime.fromtimestamp(DESERTBUS_START, tz=pytz.utc)
 DESERTBUS_END = DESERTBUS_START + datetime.timedelta(days=6) # Six days of plugs should be long enough
 
 @bot.command("(?:next(?:stream)?|sched(?:ule)?)( .*)?")
-@utils.throttle(notify=utils.PRIVATE)
+@utils.throttle(notify=utils.PRIVATE, allowprivate=True)
 def next(lrrbot, conn, event, respond_to, timezone):
 	"""
 	Command: !next
@@ -82,7 +82,7 @@ def next(lrrbot, conn, event, respond_to, timezone):
 		conn.privmsg(respond_to, googlecalendar.get_next_event_text(googlecalendar.CALENDAR_LRL, tz=timezone))
 
 @bot.command("desert ?bus( .*)?")
-@utils.throttle(notify=utils.PRIVATE)
+@utils.throttle(notify=utils.PRIVATE, allowprivate=True)
 def desertbus(lrrbot, conn, event, respond_to, timezone):
 	if not timezone:
 		timezone = config['timezone']
@@ -106,7 +106,7 @@ def desertbus(lrrbot, conn, event, respond_to, timezone):
 
 
 @bot.command("(?:nextfan(?:stream)?|fansched(?:ule)?)( .*)?")
-@utils.throttle(notify=utils.PRIVATE)
+@utils.throttle(notify=utils.PRIVATE, allowprivate=True)
 def nextfan(lrrbot, conn, event, respond_to, timezone):
 	"""
 	Command: !nextfan
@@ -120,7 +120,7 @@ def nextfan(lrrbot, conn, event, respond_to, timezone):
 	conn.privmsg(respond_to, googlecalendar.get_next_event_text(googlecalendar.CALENDAR_FAN, tz=timezone, include_current=True))
 
 @bot.command("time")
-@utils.throttle(notify=utils.PRIVATE)
+@utils.throttle(notify=utils.PRIVATE, allowprivate=True)
 def time(lrrbot, conn, event, respond_to):
 	"""
 	Command: !time
@@ -132,7 +132,7 @@ def time(lrrbot, conn, event, respond_to):
 	conn.privmsg(respond_to, "Current moonbase time: %s" % now.strftime("%l:%M %p"))
 	
 @bot.command("time 24")
-@utils.throttle(notify=utils.PRIVATE)
+@utils.throttle(notify=utils.PRIVATE, allowprivate=True)
 def time24(lrrbot, conn, event, respond_to):
 	"""
 	Command: !time 24
@@ -144,7 +144,7 @@ def time24(lrrbot, conn, event, respond_to):
 	conn.privmsg(respond_to, "Current moonbase time: %s" % now.strftime("%H:%M"))
 
 @bot.command("viewers")
-@utils.throttle(30, notify=utils.PRIVATE) # longer cooldown as this involves 2 API calls
+@utils.throttle(30, notify=utils.PRIVATE, allowprivate=True) # longer cooldown as this involves 2 API calls
 def viewers(lrrbot, conn, event, respond_to):
 	"""
 	Command: !viewers
@@ -175,7 +175,7 @@ def viewers(lrrbot, conn, event, respond_to):
 	conn.privmsg(respond_to, "%s %s" % (viewers, chatters))
 
 @bot.command("uptime")
-@utils.throttle(notify=utils.PRIVATE)
+@utils.throttle(notify=utils.PRIVATE, allowprivate=True)
 def uptime(lrrbot, conn, event, respond_to):
 	"""
 	Command: !uptime

--- a/lrrbot/commands/misc.py
+++ b/lrrbot/commands/misc.py
@@ -1,9 +1,11 @@
 import datetime
 import json
 import logging
+import random
 
 import dateutil.parser
 import pytz
+import irc.client
 
 from common import utils
 from common.config import config
@@ -174,6 +176,18 @@ def viewers(lrrbot, conn, event, respond_to):
 		chatters = "No-one in the chat."
 	conn.privmsg(respond_to, "%s %s" % (viewers, chatters))
 
+def uptime_msg(stream_info=None):
+	if stream_info is None:
+		stream_info = twitch.get_info()
+	if stream_info and stream_info.get("stream_created_at"):
+		start = dateutil.parser.parse(stream_info["stream_created_at"])
+		now = datetime.datetime.now(datetime.timezone.utc)
+		return "The stream has been live for %s." % utils.nice_duration(now-start, 0)
+	elif stream_info and stream_info.get('live'):
+		return "Twitch won't tell me when the stream went live."
+	else:
+		return "The stream is not live."
+
 @bot.command("uptime")
 @utils.throttle(notify=utils.PRIVATE, allowprivate=True)
 def uptime(lrrbot, conn, event, respond_to):
@@ -183,13 +197,81 @@ def uptime(lrrbot, conn, event, respond_to):
 
 	Post the duration the stream has been live.
 	"""
+	conn.privmsg(respond_to, uptime_msg())
 
+@utils.throttle(30, log=False) # We could easily be sending a bunch of these at once, and the info doesn't change often
+def get_status_msg():
+	messages = []
 	stream_info = twitch.get_info()
-	if stream_info and stream_info.get("stream_created_at"):
-		start = dateutil.parser.parse(stream_info["stream_created_at"])
-		now = datetime.datetime.now(datetime.timezone.utc)
-		conn.privmsg(respond_to, "The stream has been live for %s" % utils.nice_duration(now-start, 0))
-	elif stream_info:
-		conn.privmsg(respond_to, "Twitch won't tell me when the stream went live.")
+	if stream_info and stream_info.get('live'):
+		game = lrrbot.get_current_game()
+		game = game and game.get("display", game["name"])
+		show = lrrbot.show_override or lrrbot.show
+		show = show and storage.data.get("shows", {}).get(show, {}).get("name", show)
+		if game and show:
+			messages.append("Currently playing %s on %s." % (game, show))
+		elif game:
+			messages.append("Currently playing %s." % game)
+		elif show:
+			messages.append("Currently showing %s." % show)
+		messages.append(uptime_msg(stream_info))
 	else:
-		conn.privmsg(respond_to, "The stream is not live.")
+		messages.append(googlecalendar.get_next_event_text(googlecalendar.CALENDAR_LRL))
+	if 'advice' in storage.data['responses']:
+		messages.append(random.choice(storage.data['responses']['advice']['response']))
+	return ' '.join(messages)
+
+def send_status(lrrbot, conn, target):
+	conn.privmsg(target, get_status_msg())
+
+@bot.command("status")
+def status(lrrbot, conn, event, respond_to):
+	"""
+	Command: !status
+	Section: info
+
+	Send you a quick status message about the stream. If the stream is live, this
+	will include what game is being played, and how long the stream has been live.
+	Otherwise, it will tell you about the next scheduled stream.
+	"""
+	source = irc.client.NickMask(event.source)
+	send_status(lrrbot, conn, source.nick)
+
+@bot.command("auto(?: |-)?status")
+def autostatus_check(lrrbot, conn, event, respond_to):
+	"""
+	Command: !autostatus
+	Section: info
+
+	Check whether you are set to be automatically sent status messages when join join the channel.
+	"""
+	source = irc.client.NickMask(event.source)
+	if source.nick.lower() in lrrbot.autostatus:
+		conn.privmsg(source.nick, "Auto-status is enabled. Disable it with: !autostatus off")
+	else:
+		conn.privmsg(source.nick, "Auto-status is disabled. Enable it with: !autostatus on")
+
+@bot.command("auto(?: |-)?status (on|off)")
+def autostatus_set(lrrbot, conn, event, respond_to, enable):
+	"""
+	Command: !autostatus on
+	Command: !autostatus off
+	Section: info
+
+	Enable or disable automatically sending status messages when you join the channel.
+	"""
+	source = irc.client.NickMask(event.source)
+	nick = source.nick.lower()
+	enable = enable.lower() == "on"
+	if enable:
+		if nick not in lrrbot.autostatus:
+			lrrbot.autostatus.add(nick)
+			storage.data['autostatus'] = list(lrrbot.autostatus)
+			storage.save()
+		conn.privmsg(source.nick, "Auto-status enabled.")
+	else:
+		if nick in lrrbot.autostatus:
+			lrrbot.autostatus.remove(nick)
+			storage.data['autostatus'] = list(lrrbot.autostatus)
+			storage.save()
+		conn.privmsg(source.nick, "Auto-status disabled.")

--- a/lrrbot/commands/misc.py
+++ b/lrrbot/commands/misc.py
@@ -19,7 +19,7 @@ def test(lrrbot, conn, event, respond_to):
 	conn.privmsg(respond_to, "Test")
 
 @bot.command("storm(?:count)?")
-@utils.throttle(notify=utils.PRIVATE, allowprivate=True)
+@utils.throttle(notify=utils.Visibility.PRIVATE, allowprivate=True)
 def stormcount(lrrbot, conn, event, respond_to):
 	"""
 	Command: !storm
@@ -38,7 +38,7 @@ def stormcount(lrrbot, conn, event, respond_to):
 	conn.privmsg(respond_to, "Today's storm count: %d" % storage.data["storm"]["count"])
 	
 @bot.command("spam(?:count)?")
-@utils.throttle(notify=utils.PRIVATE, allowprivate=True)
+@utils.throttle(notify=utils.Visibility.PRIVATE, allowprivate=True)
 def spamcount(lrrbot, conn, event, respond_to):
 	"""
 	Command: !spam
@@ -62,7 +62,7 @@ DESERTBUS_START = datetime.datetime.fromtimestamp(DESERTBUS_START, tz=pytz.utc)
 DESERTBUS_END = DESERTBUS_START + datetime.timedelta(days=6) # Six days of plugs should be long enough
 
 @bot.command("(?:next(?:stream)?|sched(?:ule)?)( .*)?")
-@utils.throttle(notify=utils.PRIVATE, allowprivate=True)
+@utils.throttle(notify=utils.Visibility.PRIVATE, allowprivate=True)
 def next(lrrbot, conn, event, respond_to, timezone):
 	"""
 	Command: !next
@@ -84,7 +84,7 @@ def next(lrrbot, conn, event, respond_to, timezone):
 		conn.privmsg(respond_to, googlecalendar.get_next_event_text(googlecalendar.CALENDAR_LRL, tz=timezone))
 
 @bot.command("desert ?bus( .*)?")
-@utils.throttle(notify=utils.PRIVATE, allowprivate=True)
+@utils.throttle(notify=utils.Visibility.PRIVATE, allowprivate=True)
 def desertbus(lrrbot, conn, event, respond_to, timezone):
 	if not timezone:
 		timezone = config['timezone']
@@ -108,7 +108,7 @@ def desertbus(lrrbot, conn, event, respond_to, timezone):
 
 
 @bot.command("(?:nextfan(?:stream)?|fansched(?:ule)?)( .*)?")
-@utils.throttle(notify=utils.PRIVATE, allowprivate=True)
+@utils.throttle(notify=utils.Visibility.PRIVATE, allowprivate=True)
 def nextfan(lrrbot, conn, event, respond_to, timezone):
 	"""
 	Command: !nextfan
@@ -122,7 +122,7 @@ def nextfan(lrrbot, conn, event, respond_to, timezone):
 	conn.privmsg(respond_to, googlecalendar.get_next_event_text(googlecalendar.CALENDAR_FAN, tz=timezone, include_current=True))
 
 @bot.command("time")
-@utils.throttle(notify=utils.PRIVATE, allowprivate=True)
+@utils.throttle(notify=utils.Visibility.PRIVATE, allowprivate=True)
 def time(lrrbot, conn, event, respond_to):
 	"""
 	Command: !time
@@ -134,7 +134,7 @@ def time(lrrbot, conn, event, respond_to):
 	conn.privmsg(respond_to, "Current moonbase time: %s" % now.strftime("%l:%M %p"))
 	
 @bot.command("time 24")
-@utils.throttle(notify=utils.PRIVATE, allowprivate=True)
+@utils.throttle(notify=utils.Visibility.PRIVATE, allowprivate=True)
 def time24(lrrbot, conn, event, respond_to):
 	"""
 	Command: !time 24
@@ -146,7 +146,7 @@ def time24(lrrbot, conn, event, respond_to):
 	conn.privmsg(respond_to, "Current moonbase time: %s" % now.strftime("%H:%M"))
 
 @bot.command("viewers")
-@utils.throttle(30, notify=utils.PRIVATE, allowprivate=True) # longer cooldown as this involves 2 API calls
+@utils.throttle(30, notify=utils.Visibility.PRIVATE, allowprivate=True) # longer cooldown as this involves 2 API calls
 def viewers(lrrbot, conn, event, respond_to):
 	"""
 	Command: !viewers
@@ -189,7 +189,7 @@ def uptime_msg(stream_info=None):
 		return "The stream is not live."
 
 @bot.command("uptime")
-@utils.throttle(notify=utils.PRIVATE, allowprivate=True)
+@utils.throttle(notify=utils.Visibility.PRIVATE, allowprivate=True)
 def uptime(lrrbot, conn, event, respond_to):
 	"""
 	Command: !uptime

--- a/lrrbot/commands/misc.py
+++ b/lrrbot/commands/misc.py
@@ -19,7 +19,7 @@ def test(lrrbot, conn, event, respond_to):
 	conn.privmsg(respond_to, "Test")
 
 @bot.command("storm(?:count)?")
-@utils.throttle(notify=utils.Visibility.PRIVATE, allowprivate=True)
+@utils.throttle()
 def stormcount(lrrbot, conn, event, respond_to):
 	"""
 	Command: !storm
@@ -38,7 +38,7 @@ def stormcount(lrrbot, conn, event, respond_to):
 	conn.privmsg(respond_to, "Today's storm count: %d" % storage.data["storm"]["count"])
 	
 @bot.command("spam(?:count)?")
-@utils.throttle(notify=utils.Visibility.PRIVATE, allowprivate=True)
+@utils.throttle()
 def spamcount(lrrbot, conn, event, respond_to):
 	"""
 	Command: !spam
@@ -62,7 +62,7 @@ DESERTBUS_START = datetime.datetime.fromtimestamp(DESERTBUS_START, tz=pytz.utc)
 DESERTBUS_END = DESERTBUS_START + datetime.timedelta(days=6) # Six days of plugs should be long enough
 
 @bot.command("(?:next(?:stream)?|sched(?:ule)?)( .*)?")
-@utils.throttle(notify=utils.Visibility.PRIVATE, allowprivate=True)
+@utils.throttle()
 def next(lrrbot, conn, event, respond_to, timezone):
 	"""
 	Command: !next
@@ -84,7 +84,7 @@ def next(lrrbot, conn, event, respond_to, timezone):
 		conn.privmsg(respond_to, googlecalendar.get_next_event_text(googlecalendar.CALENDAR_LRL, tz=timezone))
 
 @bot.command("desert ?bus( .*)?")
-@utils.throttle(notify=utils.Visibility.PRIVATE, allowprivate=True)
+@utils.throttle()
 def desertbus(lrrbot, conn, event, respond_to, timezone):
 	if not timezone:
 		timezone = config['timezone']
@@ -108,7 +108,7 @@ def desertbus(lrrbot, conn, event, respond_to, timezone):
 
 
 @bot.command("(?:nextfan(?:stream)?|fansched(?:ule)?)( .*)?")
-@utils.throttle(notify=utils.Visibility.PRIVATE, allowprivate=True)
+@utils.throttle()
 def nextfan(lrrbot, conn, event, respond_to, timezone):
 	"""
 	Command: !nextfan
@@ -122,7 +122,7 @@ def nextfan(lrrbot, conn, event, respond_to, timezone):
 	conn.privmsg(respond_to, googlecalendar.get_next_event_text(googlecalendar.CALENDAR_FAN, tz=timezone, include_current=True))
 
 @bot.command("time")
-@utils.throttle(notify=utils.Visibility.PRIVATE, allowprivate=True)
+@utils.throttle()
 def time(lrrbot, conn, event, respond_to):
 	"""
 	Command: !time
@@ -134,7 +134,7 @@ def time(lrrbot, conn, event, respond_to):
 	conn.privmsg(respond_to, "Current moonbase time: %s" % now.strftime("%l:%M %p"))
 	
 @bot.command("time 24")
-@utils.throttle(notify=utils.Visibility.PRIVATE, allowprivate=True)
+@utils.throttle()
 def time24(lrrbot, conn, event, respond_to):
 	"""
 	Command: !time 24
@@ -146,7 +146,7 @@ def time24(lrrbot, conn, event, respond_to):
 	conn.privmsg(respond_to, "Current moonbase time: %s" % now.strftime("%H:%M"))
 
 @bot.command("viewers")
-@utils.throttle(30, notify=utils.Visibility.PRIVATE, allowprivate=True) # longer cooldown as this involves 2 API calls
+@utils.throttle(30) # longer cooldown as this involves 2 API calls
 def viewers(lrrbot, conn, event, respond_to):
 	"""
 	Command: !viewers
@@ -189,7 +189,7 @@ def uptime_msg(stream_info=None):
 		return "The stream is not live."
 
 @bot.command("uptime")
-@utils.throttle(notify=utils.Visibility.PRIVATE, allowprivate=True)
+@utils.throttle()
 def uptime(lrrbot, conn, event, respond_to):
 	"""
 	Command: !uptime
@@ -199,7 +199,7 @@ def uptime(lrrbot, conn, event, respond_to):
 	"""
 	conn.privmsg(respond_to, uptime_msg())
 
-@utils.throttle(30, log=False) # We could easily be sending a bunch of these at once, and the info doesn't change often
+@utils.cache(30) # We could easily be sending a bunch of these at once, and the info doesn't change often
 def get_status_msg():
 	messages = []
 	stream_info = twitch.get_info()

--- a/lrrbot/commands/misc.py
+++ b/lrrbot/commands/misc.py
@@ -17,7 +17,7 @@ def test(lrrbot, conn, event, respond_to):
 	conn.privmsg(respond_to, "Test")
 
 @bot.command("storm(?:count)?")
-@utils.throttle()
+@utils.throttle(notify=utils.PRIVATE)
 def stormcount(lrrbot, conn, event, respond_to):
 	"""
 	Command: !storm
@@ -36,7 +36,7 @@ def stormcount(lrrbot, conn, event, respond_to):
 	conn.privmsg(respond_to, "Today's storm count: %d" % storage.data["storm"]["count"])
 	
 @bot.command("spam(?:count)?")
-@utils.throttle()
+@utils.throttle(notify=utils.PRIVATE)
 def spamcount(lrrbot, conn, event, respond_to):
 	"""
 	Command: !spam
@@ -60,7 +60,7 @@ DESERTBUS_START = datetime.datetime.fromtimestamp(DESERTBUS_START, tz=pytz.utc)
 DESERTBUS_END = DESERTBUS_START + datetime.timedelta(days=6) # Six days of plugs should be long enough
 
 @bot.command("(?:next(?:stream)?|sched(?:ule)?)( .*)?")
-@utils.throttle()
+@utils.throttle(notify=utils.PRIVATE)
 def next(lrrbot, conn, event, respond_to, timezone):
 	"""
 	Command: !next
@@ -82,7 +82,7 @@ def next(lrrbot, conn, event, respond_to, timezone):
 		conn.privmsg(respond_to, googlecalendar.get_next_event_text(googlecalendar.CALENDAR_LRL, tz=timezone))
 
 @bot.command("desert ?bus( .*)?")
-@utils.throttle()
+@utils.throttle(notify=utils.PRIVATE)
 def desertbus(lrrbot, conn, event, respond_to, timezone):
 	if not timezone:
 		timezone = config['timezone']
@@ -106,7 +106,7 @@ def desertbus(lrrbot, conn, event, respond_to, timezone):
 
 
 @bot.command("(?:nextfan(?:stream)?|fansched(?:ule)?)( .*)?")
-@utils.throttle()
+@utils.throttle(notify=utils.PRIVATE)
 def nextfan(lrrbot, conn, event, respond_to, timezone):
 	"""
 	Command: !nextfan
@@ -120,7 +120,7 @@ def nextfan(lrrbot, conn, event, respond_to, timezone):
 	conn.privmsg(respond_to, googlecalendar.get_next_event_text(googlecalendar.CALENDAR_FAN, tz=timezone, include_current=True))
 
 @bot.command("time")
-@utils.throttle()
+@utils.throttle(notify=utils.PRIVATE)
 def time(lrrbot, conn, event, respond_to):
 	"""
 	Command: !time
@@ -132,7 +132,7 @@ def time(lrrbot, conn, event, respond_to):
 	conn.privmsg(respond_to, "Current moonbase time: %s" % now.strftime("%l:%M %p"))
 	
 @bot.command("time 24")
-@utils.throttle()
+@utils.throttle(notify=utils.PRIVATE)
 def time24(lrrbot, conn, event, respond_to):
 	"""
 	Command: !time 24
@@ -144,7 +144,7 @@ def time24(lrrbot, conn, event, respond_to):
 	conn.privmsg(respond_to, "Current moonbase time: %s" % now.strftime("%H:%M"))
 
 @bot.command("viewers")
-@utils.throttle(30) # longer cooldown as this involves 2 API calls
+@utils.throttle(30, notify=utils.PRIVATE) # longer cooldown as this involves 2 API calls
 def viewers(lrrbot, conn, event, respond_to):
 	"""
 	Command: !viewers
@@ -175,7 +175,7 @@ def viewers(lrrbot, conn, event, respond_to):
 	conn.privmsg(respond_to, "%s %s" % (viewers, chatters))
 
 @bot.command("uptime")
-@utils.throttle()
+@utils.throttle(notify=utils.PRIVATE)
 def uptime(lrrbot, conn, event, respond_to):
 	"""
 	Command: !uptime

--- a/lrrbot/commands/quote.py
+++ b/lrrbot/commands/quote.py
@@ -26,7 +26,7 @@ import datetime
 
 @bot.command("quote(?: (?:(\d+)|(.+)))?")
 @utils.sub_only
-@utils.throttle(60, count=2, notify=utils.PRIVATE, modoverride=True, allowprivate=True)
+@utils.throttle(60, count=2, notify=utils.Visibility.PRIVATE, modoverride=True, allowprivate=True)
 @utils.with_postgres
 def quote(pg_conn, cur, lrrbot, conn, event, respond_to, qid, attrib):
 	"""
@@ -164,7 +164,7 @@ def delquote(pg_conn, cur, lrrbot, conn, event, respond_to, qid):
 
 @bot.command("findquote (.*)")
 @utils.sub_only
-@utils.throttle(60, count=2, notify=utils.PRIVATE, modoverride=True, allowprivate=True)
+@utils.throttle(60, count=2, notify=utils.Visibility.PRIVATE, modoverride=True, allowprivate=True)
 @utils.with_postgres
 def findquote(pg_conn, cur, lrrbot, conn, event, respond_to, query):
 	"""

--- a/lrrbot/commands/quote.py
+++ b/lrrbot/commands/quote.py
@@ -26,7 +26,7 @@ import datetime
 
 @bot.command("quote(?: (?:(\d+)|(.+)))?")
 @utils.sub_only
-@utils.throttle(60, count=2, notify=utils.Visibility.PRIVATE, modoverride=True, allowprivate=True)
+@utils.throttle(60, count=2)
 @utils.with_postgres
 def quote(pg_conn, cur, lrrbot, conn, event, respond_to, qid, attrib):
 	"""
@@ -164,7 +164,7 @@ def delquote(pg_conn, cur, lrrbot, conn, event, respond_to, qid):
 
 @bot.command("findquote (.*)")
 @utils.sub_only
-@utils.throttle(60, count=2, notify=utils.Visibility.PRIVATE, modoverride=True, allowprivate=True)
+@utils.throttle(60, count=2)
 @utils.with_postgres
 def findquote(pg_conn, cur, lrrbot, conn, event, respond_to, query):
 	"""

--- a/lrrbot/commands/quote.py
+++ b/lrrbot/commands/quote.py
@@ -26,7 +26,7 @@ import datetime
 
 @bot.command("quote(?: (?:(\d+)|(.+)))?")
 @utils.sub_only
-@utils.throttle(60, count=2, notify=utils.PRIVATE, modoverride=True)
+@utils.throttle(60, count=2, notify=utils.PRIVATE, modoverride=True, allowprivate=True)
 @utils.with_postgres
 def quote(pg_conn, cur, lrrbot, conn, event, respond_to, qid, attrib):
 	"""
@@ -164,7 +164,7 @@ def delquote(pg_conn, cur, lrrbot, conn, event, respond_to, qid):
 
 @bot.command("findquote (.*)")
 @utils.sub_only
-@utils.throttle(60, count=2, notify=utils.PRIVATE, modoverride=True)
+@utils.throttle(60, count=2, notify=utils.PRIVATE, modoverride=True, allowprivate=True)
 @utils.with_postgres
 def findquote(pg_conn, cur, lrrbot, conn, event, respond_to, query):
 	"""

--- a/lrrbot/commands/quote.py
+++ b/lrrbot/commands/quote.py
@@ -26,7 +26,7 @@ import datetime
 
 @bot.command("quote(?: (?:(\d+)|(.+)))?")
 @utils.sub_only
-@utils.throttle(60, count=2, modoverride=True)
+@utils.throttle(60, count=2, notify=utils.PRIVATE, modoverride=True)
 @utils.with_postgres
 def quote(pg_conn, cur, lrrbot, conn, event, respond_to, qid, attrib):
 	"""
@@ -164,7 +164,7 @@ def delquote(pg_conn, cur, lrrbot, conn, event, respond_to, qid):
 
 @bot.command("findquote (.*)")
 @utils.sub_only
-@utils.throttle(60, count=2, modoverride=True)
+@utils.throttle(60, count=2, notify=utils.PRIVATE, modoverride=True)
 @utils.with_postgres
 def findquote(pg_conn, cur, lrrbot, conn, event, respond_to, query):
 	"""

--- a/lrrbot/commands/show.py
+++ b/lrrbot/commands/show.py
@@ -11,7 +11,7 @@ def show_name(show):
 	return storage.data.get("shows", {}).get(show, {}).get("name", show)
 
 @bot.command("show")
-@utils.throttle(notify=utils.PRIVATE, allowprivate=True)
+@utils.throttle(notify=utils.Visibility.PRIVATE, allowprivate=True)
 def get_show(lrrbot, conn, event, respond_to):
 	"""
 	Command: !show

--- a/lrrbot/commands/show.py
+++ b/lrrbot/commands/show.py
@@ -11,7 +11,7 @@ def show_name(show):
 	return storage.data.get("shows", {}).get(show, {}).get("name", show)
 
 @bot.command("show")
-@utils.throttle(notify=utils.PRIVATE)
+@utils.throttle(notify=utils.PRIVATE, allowprivate=True)
 def get_show(lrrbot, conn, event, respond_to):
 	"""
 	Command: !show

--- a/lrrbot/commands/show.py
+++ b/lrrbot/commands/show.py
@@ -11,7 +11,7 @@ def show_name(show):
 	return storage.data.get("shows", {}).get(show, {}).get("name", show)
 
 @bot.command("show")
-@utils.throttle()
+@utils.throttle(notify=utils.PRIVATE)
 def get_show(lrrbot, conn, event, respond_to):
 	"""
 	Command: !show

--- a/lrrbot/commands/show.py
+++ b/lrrbot/commands/show.py
@@ -11,7 +11,7 @@ def show_name(show):
 	return storage.data.get("shows", {}).get(show, {}).get("name", show)
 
 @bot.command("show")
-@utils.throttle(notify=utils.Visibility.PRIVATE, allowprivate=True)
+@utils.throttle()
 def get_show(lrrbot, conn, event, respond_to):
 	"""
 	Command: !show

--- a/lrrbot/commands/static.py
+++ b/lrrbot/commands/static.py
@@ -39,7 +39,7 @@ def generate_docstring():
 def generate_expression():
 	return "(%s)" % "|".join(re.escape(c).replace("\\ ", " ") for c in storage.data["responses"])
 
-@utils.throttle(30, params=[4], count=2, notify=utils.PRIVATE, modoverride=True)
+@utils.throttle(30, params=[4], count=2, notify=utils.PRIVATE, modoverride=True, allowprivate=True)
 def static_response(lrrbot, conn, event, respond_to, command):
 	command = " ".join(command.split())
 	response_data = storage.data["responses"][command.lower()]

--- a/lrrbot/commands/static.py
+++ b/lrrbot/commands/static.py
@@ -39,7 +39,7 @@ def generate_docstring():
 def generate_expression():
 	return "(%s)" % "|".join(re.escape(c).replace("\\ ", " ") for c in storage.data["responses"])
 
-@utils.throttle(30, params=[4], count=2, modoverride=True)
+@utils.throttle(30, params=[4], count=2, notify=utils.PRIVATE, modoverride=True)
 def static_response(lrrbot, conn, event, respond_to, command):
 	command = " ".join(command.split())
 	response_data = storage.data["responses"][command.lower()]

--- a/lrrbot/commands/static.py
+++ b/lrrbot/commands/static.py
@@ -39,7 +39,7 @@ def generate_docstring():
 def generate_expression():
 	return "(%s)" % "|".join(re.escape(c).replace("\\ ", " ") for c in storage.data["responses"])
 
-@utils.throttle(30, params=[4], count=2, notify=utils.Visibility.PRIVATE, modoverride=True, allowprivate=True)
+@utils.throttle(30, params=[4], count=2)
 def static_response(lrrbot, conn, event, respond_to, command):
 	command = " ".join(command.split())
 	response_data = storage.data["responses"][command.lower()]

--- a/lrrbot/commands/static.py
+++ b/lrrbot/commands/static.py
@@ -39,7 +39,7 @@ def generate_docstring():
 def generate_expression():
 	return "(%s)" % "|".join(re.escape(c).replace("\\ ", " ") for c in storage.data["responses"])
 
-@utils.throttle(30, params=[4], count=2, notify=utils.PRIVATE, modoverride=True, allowprivate=True)
+@utils.throttle(30, params=[4], count=2, notify=utils.Visibility.PRIVATE, modoverride=True, allowprivate=True)
 def static_response(lrrbot, conn, event, respond_to, command):
 	command = " ".join(command.split())
 	response_data = storage.data["responses"][command.lower()]

--- a/lrrbot/commands/stats.py
+++ b/lrrbot/commands/stats.py
@@ -18,7 +18,7 @@ def stat_update(lrrbot, stat, n, set_=False):
 	return game
 
 @bot.command("(%s)" % re_stats)
-@utils.throttle(30, notify=True, params=[4])
+@utils.throttle(30, notify=utils.PUBLIC, params=[4])
 def increment(lrrbot, conn, event, respond_to, stat):
 	stat = stat.lower()
 	if stat == "completed":
@@ -64,7 +64,7 @@ def stat_set(lrrbot, conn, event, respond_to, stat, n):
 	stat_print.__wrapped__(lrrbot, conn, event, respond_to, stat, game)
 
 @bot.command("(%s)count" % re_stats)
-@utils.throttle(params=[4])
+@utils.throttle(params=[4], notify=utils.PRIVATE)
 def stat_print(lrrbot, conn, event, respond_to, stat, game=None, with_emote=False):
 	stat = stat.lower()
 	if game is None:
@@ -83,7 +83,7 @@ def stat_print(lrrbot, conn, event, respond_to, stat, game=None, with_emote=Fals
 	conn.privmsg(respond_to, "%s%d %s for %s on %s" % (emote, count, display, game_name(game), show_name(show)))
 
 @bot.command("total(%s)s?" % re_stats)
-@utils.throttle(params=[4])
+@utils.throttle(params=[4], notify=utils.PRIVATE)
 def printtotal(lrrbot, conn, event, respond_to, stat):
 	stat = stat.lower()
 	count = 0

--- a/lrrbot/commands/stats.py
+++ b/lrrbot/commands/stats.py
@@ -19,7 +19,7 @@ def stat_update(lrrbot, stat, n, set_=False):
 
 @bot.command("(%s)" % re_stats)
 @utils.public_only
-@utils.throttle(30, notify=utils.Visibility.PUBLIC, params=[4])
+@utils.throttle(30, notify=utils.Visibility.PUBLIC, params=[4], modoverride=False, allowprivate=False)
 def increment(lrrbot, conn, event, respond_to, stat):
 	stat = stat.lower()
 	if stat == "completed":
@@ -65,7 +65,7 @@ def stat_set(lrrbot, conn, event, respond_to, stat, n):
 	stat_print.__wrapped__(lrrbot, conn, event, respond_to, stat, game)
 
 @bot.command("(%s)count" % re_stats)
-@utils.throttle(params=[4], notify=utils.Visibility.PRIVATE, allowprivate=True)
+@utils.throttle(params=[4])
 def stat_print(lrrbot, conn, event, respond_to, stat, game=None, with_emote=False):
 	stat = stat.lower()
 	if game is None:
@@ -84,7 +84,7 @@ def stat_print(lrrbot, conn, event, respond_to, stat, game=None, with_emote=Fals
 	conn.privmsg(respond_to, "%s%d %s for %s on %s" % (emote, count, display, game_name(game), show_name(show)))
 
 @bot.command("total(%s)s?" % re_stats)
-@utils.throttle(params=[4], notify=utils.Visibility.PRIVATE, allowprivate=True)
+@utils.throttle(params=[4])
 def printtotal(lrrbot, conn, event, respond_to, stat):
 	stat = stat.lower()
 	count = 0

--- a/lrrbot/commands/stats.py
+++ b/lrrbot/commands/stats.py
@@ -18,6 +18,7 @@ def stat_update(lrrbot, stat, n, set_=False):
 	return game
 
 @bot.command("(%s)" % re_stats)
+@utils.public_only
 @utils.throttle(30, notify=utils.PUBLIC, params=[4])
 def increment(lrrbot, conn, event, respond_to, stat):
 	stat = stat.lower()
@@ -64,7 +65,7 @@ def stat_set(lrrbot, conn, event, respond_to, stat, n):
 	stat_print.__wrapped__(lrrbot, conn, event, respond_to, stat, game)
 
 @bot.command("(%s)count" % re_stats)
-@utils.throttle(params=[4], notify=utils.PRIVATE)
+@utils.throttle(params=[4], notify=utils.PRIVATE, allowprivate=True)
 def stat_print(lrrbot, conn, event, respond_to, stat, game=None, with_emote=False):
 	stat = stat.lower()
 	if game is None:
@@ -83,7 +84,7 @@ def stat_print(lrrbot, conn, event, respond_to, stat, game=None, with_emote=Fals
 	conn.privmsg(respond_to, "%s%d %s for %s on %s" % (emote, count, display, game_name(game), show_name(show)))
 
 @bot.command("total(%s)s?" % re_stats)
-@utils.throttle(params=[4], notify=utils.PRIVATE)
+@utils.throttle(params=[4], notify=utils.PRIVATE, allowprivate=True)
 def printtotal(lrrbot, conn, event, respond_to, stat):
 	stat = stat.lower()
 	count = 0

--- a/lrrbot/commands/stats.py
+++ b/lrrbot/commands/stats.py
@@ -19,7 +19,7 @@ def stat_update(lrrbot, stat, n, set_=False):
 
 @bot.command("(%s)" % re_stats)
 @utils.public_only
-@utils.throttle(30, notify=utils.PUBLIC, params=[4])
+@utils.throttle(30, notify=utils.Visibility.PUBLIC, params=[4])
 def increment(lrrbot, conn, event, respond_to, stat):
 	stat = stat.lower()
 	if stat == "completed":
@@ -65,7 +65,7 @@ def stat_set(lrrbot, conn, event, respond_to, stat, n):
 	stat_print.__wrapped__(lrrbot, conn, event, respond_to, stat, game)
 
 @bot.command("(%s)count" % re_stats)
-@utils.throttle(params=[4], notify=utils.PRIVATE, allowprivate=True)
+@utils.throttle(params=[4], notify=utils.Visibility.PRIVATE, allowprivate=True)
 def stat_print(lrrbot, conn, event, respond_to, stat, game=None, with_emote=False):
 	stat = stat.lower()
 	if game is None:
@@ -84,7 +84,7 @@ def stat_print(lrrbot, conn, event, respond_to, stat, game=None, with_emote=Fals
 	conn.privmsg(respond_to, "%s%d %s for %s on %s" % (emote, count, display, game_name(game), show_name(show)))
 
 @bot.command("total(%s)s?" % re_stats)
-@utils.throttle(params=[4], notify=utils.PRIVATE, allowprivate=True)
+@utils.throttle(params=[4], notify=utils.Visibility.PRIVATE, allowprivate=True)
 def printtotal(lrrbot, conn, event, respond_to, stat):
 	stat = stat.lower()
 	count = 0

--- a/lrrbot/commands/strawpoll.py
+++ b/lrrbot/commands/strawpoll.py
@@ -25,7 +25,7 @@ def check_polls(lrrbot, conn):
 	lrrbot.polls = list(filter(lambda e: e[0] >= now, lrrbot.polls))
 
 @bot.command("polls")
-@utils.throttle(notify=utils.PRIVATE, allowprivate=True)
+@utils.throttle(notify=utils.Visibility.PRIVATE, allowprivate=True)
 def polls(lrrbot, conn, event, respond_to):
 	"""
 	Command: !polls

--- a/lrrbot/commands/strawpoll.py
+++ b/lrrbot/commands/strawpoll.py
@@ -25,7 +25,7 @@ def check_polls(lrrbot, conn):
 	lrrbot.polls = list(filter(lambda e: e[0] >= now, lrrbot.polls))
 
 @bot.command("polls")
-@utils.throttle(notify=utils.Visibility.PRIVATE, allowprivate=True)
+@utils.throttle()
 def polls(lrrbot, conn, event, respond_to):
 	"""
 	Command: !polls

--- a/lrrbot/commands/strawpoll.py
+++ b/lrrbot/commands/strawpoll.py
@@ -25,7 +25,7 @@ def check_polls(lrrbot, conn):
 	lrrbot.polls = list(filter(lambda e: e[0] >= now, lrrbot.polls))
 
 @bot.command("polls")
-@utils.throttle()
+@utils.throttle(notify=utils.PRIVATE)
 def polls(lrrbot, conn, event, respond_to):
 	"""
 	Command: !polls

--- a/lrrbot/commands/strawpoll.py
+++ b/lrrbot/commands/strawpoll.py
@@ -25,7 +25,7 @@ def check_polls(lrrbot, conn):
 	lrrbot.polls = list(filter(lambda e: e[0] >= now, lrrbot.polls))
 
 @bot.command("polls")
-@utils.throttle(notify=utils.PRIVATE)
+@utils.throttle(notify=utils.PRIVATE, allowprivate=True)
 def polls(lrrbot, conn, event, respond_to):
 	"""
 	Command: !polls

--- a/lrrbot/googlecalendar.py
+++ b/lrrbot/googlecalendar.py
@@ -149,9 +149,9 @@ def get_next_event_text(calendar, after=None, include_current=None, tz=None, ver
 
 	if verbose:
 		if calendar == CALENDAR_LRL:
-			response = "Next scheduled stream: " + response
+			response = "Next scheduled stream: %s." % response
 		elif calendar == CALENDAR_FAN:
-			response = "Next scheduled fan stream: " + response
+			response = "Next scheduled fan stream: %s." % response
 
 	return utils.shorten(response, 450) # For safety
 

--- a/lrrbot/googlecalendar.py
+++ b/lrrbot/googlecalendar.py
@@ -22,7 +22,7 @@ DISPLAY_FORMAT = "%a %I:%M %p %Z"
 HISTORY_PERIOD = datetime.timedelta(hours=1) # How long ago can an event have started to count as "recent"?
 LOOKAHEAD_PERIOD = datetime.timedelta(hours=1) # How close together to events have to be to count as "the same time"?
 
-@utils.throttle(CACHE_EXPIRY, params=[0])
+@utils.cache(CACHE_EXPIRY, params=[0])
 def get_upcoming_events(calendar, after=None):
 	"""
 	Get the next several events from the calendar. Will include the currently-happening

--- a/lrrbot/serverevents.py
+++ b/lrrbot/serverevents.py
@@ -77,6 +77,7 @@ def get_commands(lrrbot, user, data):
 				"aliases": cmd.get_all("command"),
 				"mod-only": cmd.get("mod-only") == "true",
 				"sub-only": cmd.get("sub-only") == "true",
+				"public-only": cmd.get("public-only") == "true",
 				"throttled": (int(cmd.get("throttle-count", 1)), int(cmd.get("throttled"))) if "throttled" in cmd else None,
 				"literal-response": cmd.get("literal-response") == "true",
 				"section": cmd.get("section"),

--- a/lrrbot/twitch.py
+++ b/lrrbot/twitch.py
@@ -97,7 +97,6 @@ def get_subscribers(channel=None, count=5, offset=None, latest=True):
 		for sub in subscriber_data['subscriptions']
 	]
 
-@utils.throttle(15*60)
 def get_group_servers():
 	"""
 	Get the secondary Twitch chat servers

--- a/lrrbot/twitch.py
+++ b/lrrbot/twitch.py
@@ -1,5 +1,6 @@
 import json
 import random
+import asyncio
 
 from common import utils
 from common.config import config
@@ -76,6 +77,7 @@ def get_game_playing(username=None):
 		return get_game(name=channel_data['game'])
 	return None
 
+@asyncio.coroutine
 def get_subscribers(channel=None, count=5, offset=None, latest=True):
 	if channel is None:
 		channel = config['channel']
@@ -90,7 +92,7 @@ def get_subscribers(channel=None, count=5, offset=None, latest=True):
 	}
 	if offset is not None:
 		data['offset'] = offset
-	res = utils.http_request("https://api.twitch.tv/kraken/channels/%s/subscriptions" % channel, headers=headers, data=data)
+	res = yield from utils.http_request_coro("https://api.twitch.tv/kraken/channels/%s/subscriptions" % channel, headers=headers, data=data)
 	subscriber_data = json.loads(res)
 	return [
 		(sub['user']['display_name'], sub['user'].get('logo'), sub['created_at'])

--- a/lrrbot/twitchsubs.py
+++ b/lrrbot/twitchsubs.py
@@ -1,34 +1,30 @@
-import queue
 import threading
 import time
 import logging
 import dateutil
+import asyncio
 from common import utils
 from common.config import config
 from lrrbot import twitch
 
 log = logging.getLogger('twitchsubs')
 
-new_subs = queue.Queue()
-
-# Twitch API subscriber polling lives in its own thread, as sometimes this API
-# call hangs or locks, and we don't want to kill the bot while we wait for timeout.
-def createthread():
-	thread = threading.Thread(target=run_thread, name="twitchsubs")
-	thread.setDaemon(True)
-	thread.start()
-
-def run_thread():
-	while True:
-		do_check()
-		time.sleep(config['checksubstime'])
+@asyncio.coroutine
+def watch_subs(lrrbot):
+	try:
+		while True:
+			yield from do_check(lrrbot)
+			yield from asyncio.sleep(config['checksubstime'])
+	except asyncio.CancelledError:
+		pass
 
 last_subs = None
-@utils.swallow_errors
-def do_check():
+@utils.swallow_errors_coro
+@asyncio.coroutine
+def do_check(lrrbot):
 	global last_subs
 
-	sublist = twitch.get_subscribers(config['channel'])
+	sublist = yield from twitch.get_subscribers(config['channel'])
 	if not sublist:
 		log.info("Failed to get subscriber list from Twitch")
 		last_subs = None
@@ -42,9 +38,8 @@ def do_check():
 			if user.lower() not in last_subs:
 				log.info("Found new subscriber via Twitch API: %s" % user)
 				eventtime = dateutil.parser.parse(eventtime).timestamp()
-				new_subs.put((user, logo, eventtime, config['channel']))
+				lrrbot.on_api_subscriber(user, logo, eventtime, config['channel'])
 	else:
 		log.debug("Got initial subscriber list from Twitch")
 
 	last_subs = [i[0].lower() for i in sublist]
-

--- a/lrrbot/twitchsubs.py
+++ b/lrrbot/twitchsubs.py
@@ -1,4 +1,3 @@
-import threading
 import time
 import logging
 import dateutil

--- a/lrrbot/twitchsubs.py
+++ b/lrrbot/twitchsubs.py
@@ -18,7 +18,7 @@ def watch_subs(lrrbot):
 		pass
 
 last_subs = None
-@utils.swallow_errors_coro
+@utils.swallow_errors
 @asyncio.coroutine
 def do_check(lrrbot):
 	global last_subs

--- a/lrrbot/whisper.py
+++ b/lrrbot/whisper.py
@@ -22,7 +22,6 @@ class TwitchWhisper(irc.bot.SingleServerIRCBot):
 		)
 
 		self.reactor.execute_every(period=config['keepalivetime'], function=self.do_keepalive)
-		self.current_connection = None
 		self.reactor.add_global_handler('welcome', self.on_connect)
 
 	@utils.swallow_errors
@@ -38,11 +37,10 @@ class TwitchWhisper(irc.bot.SingleServerIRCBot):
 		log.info("Connected to group chat server")
 		conn.cap("REQ", "twitch.tv/tags") # get metadata tags
 		conn.cap("REQ", "twitch.tv/commands") # get special commands
-		self.current_connection = conn
 
 	def add_whisper_handler(self, handler):
 		self.reactor.add_global_handler('whisper', handler)
 
 	def whisper(self, target, text):
-		if self.current_connection:
-			self.current_connection.privmsg("#jtv", "/w %s %s" % (target, text))
+		if self.connection:
+			self.connection.privmsg("#jtv", "/w %s %s" % (target, text))

--- a/lrrbot/whisper.py
+++ b/lrrbot/whisper.py
@@ -1,0 +1,48 @@
+import irc.bot, irc.client
+from common import utils
+from common.config import config
+from lrrbot import twitch, storage
+import logging
+import select
+
+log = logging.getLogger('whisper')
+
+class TwitchWhisper(irc.bot.SingleServerIRCBot):
+	def __init__(self):
+		servers = [irc.bot.ServerSpec(
+			host=host,
+			port=port,
+			password="oauth:%s" % storage.data['twitch_oauth'][config['username']] if config['password'] == "oauth" else config['password'],
+		) for host, port in twitch.get_group_servers()]
+		super(TwitchWhisper, self).__init__(
+			server_list=servers,
+			realname=config['username'],
+			nickname=config['username'],
+			reconnection_interval=config['reconnecttime'],
+		)
+
+		self.reactor.execute_every(period=config['keepalivetime'], function=self.do_keepalive)
+		self.current_connection = None
+		self.reactor.add_global_handler('welcome', self.on_connect)
+
+	@utils.swallow_errors
+	def do_keepalive(self):
+		"""Send a ping to the server, to ensure our connection stays alive, or to detect when it drops out."""
+		try:
+			self.connection.ping("keep-alive")
+		except irc.client.ServerNotConnectedError:
+			pass
+
+	def on_connect(self, conn, event):
+		"""On connecting to the server, set up the connection"""
+		log.info("Connected to group chat server")
+		conn.cap("REQ", "twitch.tv/tags") # get metadata tags
+		conn.cap("REQ", "twitch.tv/commands") # get special commands
+		self.current_connection = conn
+
+	def add_whisper_handler(self, handler):
+		self.reactor.add_global_handler('whisper', handler)
+
+	def whisper(self, target, text):
+		if self.current_connection:
+			self.current_connection.privmsg("#jtv", "/w %s %s" % (target, text))

--- a/lrrbot/whisper.py
+++ b/lrrbot/whisper.py
@@ -1,14 +1,15 @@
 import irc.bot, irc.client
 from common import utils
 from common.config import config
-from lrrbot import twitch, storage
+from lrrbot import twitch, storage, asyncreactor
 import logging
 import select
 
 log = logging.getLogger('whisper')
 
 class TwitchWhisper(irc.bot.SingleServerIRCBot):
-	def __init__(self):
+	def __init__(self, loop):
+		self.loop = loop
 		servers = [irc.bot.ServerSpec(
 			host=host,
 			port=port,
@@ -23,6 +24,9 @@ class TwitchWhisper(irc.bot.SingleServerIRCBot):
 
 		self.reactor.execute_every(period=config['keepalivetime'], function=self.do_keepalive)
 		self.reactor.add_global_handler('welcome', self.on_connect)
+
+	def reactor_class(self):
+		return asyncreactor.AsyncReactor(self.loop)
 
 	@utils.swallow_errors
 	def do_keepalive(self):

--- a/rebuild_chat_logs.py
+++ b/rebuild_chat_logs.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python3
-from lrrbot.chatlog import createthread, rebuild_all, exitthread
+from lrrbot.chatlog import run_task, rebuild_all, stop_task
+import asyncio
 
-createthread()
+loop = asyncio.get_event_loop()
+task = asyncio.async(run_task())
 rebuild_all()
-exitthread()
+stop_task()
+loop.run_until_complete(task)
+loop.close()

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pycrypto>=2.6.0
 flask-csrf>=0.9.2
 psycopg2>=2.5.4
 timelib>=0.2.4
+aiohttp>=0.17.0

--- a/start_bot.py
+++ b/start_bot.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from lrrbot import bot, log, chatlog, twitchsubs
+from lrrbot import bot, log, chatlog
 from common.config import config
 
 
@@ -17,7 +17,6 @@ import lrrbot.serverevents
 bot.compile()
 
 chatlog.createthread()
-twitchsubs.createthread()
 
 try:
 	log.info("Bot startup")

--- a/start_bot.py
+++ b/start_bot.py
@@ -16,8 +16,6 @@ import lrrbot.commands
 import lrrbot.serverevents
 bot.compile()
 
-chatlog.createthread()
-
 try:
 	log.info("Bot startup")
 	bot.start()
@@ -26,4 +24,3 @@ except (KeyboardInterrupt, SystemExit):
 finally:
 	log.info("Bot shutdown")
 	logging.shutdown()
-	chatlog.exitthread()

--- a/www/archive.py
+++ b/www/archive.py
@@ -20,7 +20,7 @@ CACHE_TIMEOUT = 5*60
 BEFORE_BUFFER = datetime.timedelta(minutes=15)
 AFTER_BUFFER = datetime.timedelta(minutes=15)
 
-@utils.throttle(CACHE_TIMEOUT, params=[0, 1])
+@utils.cache(CACHE_TIMEOUT, params=[0, 1])
 def archive_feed_data(channel, broadcasts):
 	url = "https://api.twitch.tv/kraken/channels/%s/videos?broadcasts=%s&limit=%d" % (urllib.parse.quote(channel, safe=""), "true" if broadcasts else "false", 100)
 	fp = urllib.request.urlopen(url)
@@ -89,7 +89,7 @@ def chat_data(conn, cur, starttime, endtime, target="#loadingreadyrun"):
 	))
 	return [message for (message,) in cur]
 
-@utils.throttle(CACHE_TIMEOUT, params=[0])
+@utils.cache(CACHE_TIMEOUT, params=[0])
 def get_video_data(videoid):
 	try:
 		with contextlib.closing(urllib.request.urlopen("https://api.twitch.tv/kraken/videos/%s" % videoid)) as fp:

--- a/www/static/style.css
+++ b/www/static/style.css
@@ -471,6 +471,9 @@ table.spam-find tr.spam {
 .label.subonly {
 	background-color: #5BC0DE;
 }
+.label.publiconly {
+	background-color: #AA4;
+}
 dd {
 	margin: 0;
 	padding: 0 0 0 2.5em;

--- a/www/templates/help.html
+++ b/www/templates/help.html
@@ -28,6 +28,7 @@ $(modonly);
     {% if command["throttled"] != None %}<span class="label timeout" title="This command can be used at most {{ command["throttled"][0] }} time{%if command["throttled"][0] != 1%}s{%endif%} every {{ command["throttled"][1] }} second{%if command["throttled"][1] != 1%}s{%endif%}">
     	&#x231B; {%if command["throttled"][0] > 1%}{{ command["throttled"][0] }}/{%endif%}{{ command["throttled"][1] }}
    	</span>{% endif %}
+    {% if command["public-only"] %}<span class="label publiconly" title="This command cannot be used via whispers (private messaging)">Public only</span>{% endif %}
     {% if command["sub-only"] %}<span class="label subonly" title="This command can only be used by subscribers to the channel">Sub only</span>{% endif %}
     {% if command["mod-only"] %}<span class="label modonly" title="This command can only be used by moderators of the channel">Mod only</span>{% endif %}
   	</dt>
@@ -51,7 +52,7 @@ $(modonly);
 	<li><code>busstop</code> &ndash; you can't prove it won't happen</li>
 </ul>
 <dl>
-    <dt><code>!</code><i>stat</i><span class="label timeout" title="This command can be used at most 1 time every 30 seconds">&#x231B; 30</span></dt>
+    <dt><code>!</code><i>stat</i><span class="label timeout" title="This command can be used at most 1 time every 30 seconds">&#x231B; 30</span><span class="label publiconly" title="This command cannot be used via whispers (private messaging)">Public only</span></dt>
 	<dd>eg: <code>!death</code></dd>
 	<dd>Adds 1 to the stat counter for the current game</dd>
     <dt class="modonly"><code>!</code><i>stat</i><code> add </code><i>#</i><span class="label modonly" title="This command can only be used by moderators of the channel">Mod only</span></dt>


### PR DESCRIPTION
Bunch of changes for Twitch whispers:
* Separate class that handles connection to the group chat servers and sends/receives whispers. Is mostly decoupled from the main bot, so in theory it can be replaced if the mechanism changes. As far as most of the bot's concerned, it's just sending and receiving private messages in the normal IRC manner.
* Users can now send commands via whisper, and get responses via whisper. For some commands this is disabled (specifically ones that modify bot state, like `!death`), though mods can use any command (but I'd prefer you don't). Doing so also avoids the anti-spam throttles.
* Commands that used to be throttled silently will now send notifications via whisper. Commands that used to be throttled publicly (eg `!death`) still will be.
* New command `!autostatus` that allows users to opt-in to receiving a status update when they join the channel. If the stream is live, this is essentially a summary of `!game`, `!show` and `!uptime`, while if the stream is offline it will send `!next`. Also includes `!advice`, because of course it does. For users who don't want the automatic message there's also just `!status` which sends that as a one-time message (but still as a whisper, to keep the chat from being spammed).
  * Note that Twitch join/part messages get sent in batches, so these automatic whispers may show up as much as a minute after you actually join the chat. I think that's still sufficient.

Whole thing seems a bit too major to just push live like I normally do, so here, I'll do the proper code-review thing for once.