### PR TITLE
!live, !live register, !live CHANNEL

### DIFF
--- a/common/utils.py
+++ b/common/utils.py
@@ -439,6 +439,7 @@ def http_request_coro(url, data=None, method='GET', maxtries=3, headers={}, time
 		try:
 			res = yield from asyncio.wait_for(http_request_session.request(method, url, params=params, data=data, headers=headers), timeout)
 			if res.status // 100 != 2:
+				yield from res.read()
 				raise urllib.error.HTTPError(res.url, res.status, res.reason, res.headers, None)
 			return (yield from res.text())
 		except Exception as e:

--- a/common/utils.py
+++ b/common/utils.py
@@ -132,6 +132,8 @@ def coro_decorator(decorator):
 					return e.value
 				else:
 					raise Exception("Decorator %s behaving badly wrapping non-coroutine %s" % (decorator.__name__, func.__name__))
+			# Without this `asyncio` thinks that `decorated_func` is a coroutine function.
+			decorated_func._is_coroutine = False
 			return decorated_func
 	return wrapper
 

--- a/common/utils.py
+++ b/common/utils.py
@@ -438,8 +438,11 @@ def http_request_coro(url, data=None, method='GET', maxtries=3, headers={}, time
 	while True:
 		try:
 			res = yield from asyncio.wait_for(http_request_session.request(method, url, params=params, data=data, headers=headers), timeout)
-			if res.status // 100 != 2:
+			status_class = res.status // 100
+			if status_class != 2:
 				yield from res.read()
+				if status_class == 4:
+					maxtries = 1
 				raise urllib.error.HTTPError(res.url, res.status, res.reason, res.headers, None)
 			return (yield from res.text())
 		except Exception as e:

--- a/common/utils.py
+++ b/common/utils.py
@@ -424,6 +424,8 @@ def http_request(url, data=None, method='GET', maxtries=3, headers={}, timeout=5
 				break
 	raise firstex
 
+# Limit the number of parallel HTTP connections to a server.
+http_request_session = aiohttp.ClientSession(connector=aiohttp.TCPConnector(limit=6))
 @asyncio.coroutine
 def http_request_coro(url, data=None, method='GET', maxtries=3, headers={}, timeout=5):
 	headers["User-Agent"] = "LRRbot/2.0 (http://lrrbot.mrphlip.com/)"
@@ -435,7 +437,7 @@ def http_request_coro(url, data=None, method='GET', maxtries=3, headers={}, time
 		params = None
 	while True:
 		try:
-			res = yield from asyncio.wait_for(aiohttp.request(method, url, params=params, data=data, headers=headers), timeout)
+			res = yield from asyncio.wait_for(http_request_session.request(method, url, params=params, data=data, headers=headers), timeout)
 			if res.status // 100 != 2:
 				raise urllib.error.HTTPError(res.url, res.status, res.reason, res.headers, None)
 			return (yield from res.text())

--- a/lrrbot/commands/__init__.py
+++ b/lrrbot/commands/__init__.py
@@ -9,3 +9,4 @@ import lrrbot.commands.static
 import lrrbot.commands.stats
 import lrrbot.commands.strawpoll
 import lrrbot.commands.quote
+import lrrbot.commands.live

--- a/lrrbot/commands/live.py
+++ b/lrrbot/commands/live.py
@@ -1,0 +1,99 @@
+from lrrbot.main import bot
+from lrrbot import twitch
+from lrrbot import storage
+from lrrbot import googlecalendar
+from common import utils
+from common.config import config
+import asyncio
+import json
+import urllib.parse
+import urllib.error
+
+@utils.cache(24 * 60 * 60)
+@asyncio.coroutine
+def extract_new_channels(loop):
+	data = yield from utils.http_request_coro(googlecalendar.EVENTS_URL % urllib.parse.quote(googlecalendar.CALENDAR_FAN), {
+		"key": config["google_key"],
+		"maxResults": 25000,
+	})
+	data = json.loads(data)
+
+	channels = set()
+
+	for event in data["items"]:
+		if "location" in event:
+			for token in event["location"].split():
+				url = urllib.parse.urlparse(token)
+				if url.scheme == "":
+					url = urllib.parse.urlparse("https://" + token)
+				if url.netloc in {"www.twitch.tv", "twitch.tv"}:
+					try:
+						channel = url.path.split("/")[1].lower()
+					except IndexError:
+						continue
+					channels.add(channel)
+
+	storage.data.setdefault("fan_channels", [])
+	new_channels = list(channels.difference(storage.data["fan_channels"]))
+	channels_data = yield from asyncio.gather(*[twitch.get_stream_info(channel) for channel in new_channels], loop=loop, return_exceptions=True)
+	for channel, data in zip(new_channels, channels_data):
+		if isinstance(data, dict) and "error" not in data:
+			storage.data["fan_channels"].append(channel)
+	storage.save()
+
+@bot.command("live")
+@utils.throttle()
+@asyncio.coroutine
+def live(lrrbot, conn, event, respond_to):
+	"""
+	Command: !live
+	
+	Post the currenly live fanstreamers.
+	"""
+
+	try:
+		yield from extract_new_channels(lrrbot.loop)
+	except urllib.error.HTTPError:
+		pass
+
+	streams = yield from asyncio.gather(*[
+		twitch.get_stream_info(channel)
+		for channel in storage.data.get("fan_channels", [])
+	], loop=lrrbot.loop)
+	streams = [data for data in streams if data.get("stream") is not None]
+	if streams == []:
+		return conn.privmsg(respond_to, "No fanstreamers currently live.")
+
+	tag = "Currently live fanstreamers: "
+
+	# Full message
+	message = tag + ", ".join([
+		"%s (%s) is playing %s (%s)" % (
+			data["stream"]["channel"]["display_name"],
+			data["stream"]["channel"]["url"],
+			data["stream"]["game"],
+			data["stream"]["channel"]["status"]
+		) for data in streams
+	])
+	if len(message) <= 450:
+		return conn.privmsg(respond_to, message)
+
+	# Shorter message
+	message = tag + ", ".join([
+		"%s (%s) is playing %s" % (
+			data["stream"]["channel"]["display_name"],
+			data["stream"]["channel"]["url"],
+			data["stream"]["game"],
+		) for data in streams
+	])
+	if len(message) <= 450:
+		return conn.privmsg(respond_to, message)
+
+	# Shortest message
+	message = tag + ", ".join([
+		"%s (%s)" % (
+			data["stream"]["channel"]["display_name"],
+			data["stream"]["channel"]["url"]
+		) for data in streams
+	])
+	return conn.privmsg(respond_to, utils.shorten(message, 450))

--- a/lrrbot/commands/live.py
+++ b/lrrbot/commands/live.py
@@ -65,6 +65,8 @@ def live(lrrbot, conn, event, respond_to):
 	if streams == []:
 		return conn.privmsg(respond_to, "No fanstreamers currently live.")
 
+	streams.sort(key=lambda e: e["stream"]["channel"]["display_name"])
+
 	tag = "Currently live fanstreamers: "
 
 	# Full message

--- a/lrrbot/commands/live.py
+++ b/lrrbot/commands/live.py
@@ -121,5 +121,9 @@ def register(lrrbot, conn, event, respond_to, channel):
 
 	Register CHANNEL as a fanstreamer channel.
 	"""
-	storage.data["fan_channels"] = list(set(storage.data.get("fan_channels", []) + [channel]))
-	conn.privmsg(respond_to, "Channel '%s' added to the fanstreamer list." % channel)
+	try:
+		yield from twitch.get_stream_info(channel)
+		storage.data["fan_channels"] = list(set(storage.data.get("fan_channels", []) + [channel]))
+		conn.privmsg(respond_to, "Channel '%s' added to the fanstreamer list." % channel)
+	except urllib.error.HTTPError:
+		conn.privmsg(respond_to, "'%s' isn't a Twitch channel." % channel)

--- a/lrrbot/commands/live.py
+++ b/lrrbot/commands/live.py
@@ -8,6 +8,7 @@ import asyncio
 import json
 import urllib.parse
 import urllib.error
+import irc.client
 
 @utils.cache(24 * 60 * 60)
 @asyncio.coroutine
@@ -97,3 +98,26 @@ def live(lrrbot, conn, event, respond_to):
 		) for data in streams
 	])
 	return conn.privmsg(respond_to, utils.shorten(message, 450))
+
+
+@bot.command("live register")
+def register_self(lrrbot, conn, event, respond_to):
+	"""
+	Command: !live register
+
+	Register your channel as a fanstreamer channel.
+	"""
+	channel = irc.client.NickMask(event.source).nick.lower()
+	storage.data["fan_channels"] = list(set(storage.data.get("fan_channels", []) + [channel]))
+	conn.privmsg(respond_to, "Channel '%s' added to the fanstreamer list." % channel)
+
+@bot.command("live register (.*)")
+@utils.mod_only
+def register(lrrbot, conn, event, respond_to, channel):
+	"""
+	Command: !live register CHANNEL
+
+	Register CHANNEL as a fanstreamer channel.
+	"""
+	storage.data["fan_channels"] = list(set(storage.data.get("fan_channels", []) + [channel]))
+	conn.privmsg(respond_to, "Channel '%s' added to the fanstreamer list." % channel)

--- a/lrrbot/commands/live.py
+++ b/lrrbot/commands/live.py
@@ -71,11 +71,11 @@ def live(lrrbot, conn, event, respond_to):
 
 	# Full message
 	message = tag + ", ".join([
-		"%s (%s) is playing %s (%s)" % (
+		"%s (%s)%s%s" % (
 			data["stream"]["channel"]["display_name"],
 			data["stream"]["channel"]["url"],
-			data["stream"]["game"],
-			data["stream"]["channel"]["status"]
+			" is playing %s" % data["stream"]["game"] if data["stream"].get("game") is not None else "",
+			" (%s)" % data["stream"]["channel"]["status"] if data["stream"]["channel"].get("status") not in [None, ""] else ""
 		) for data in streams
 	])
 	if len(message) <= 450:
@@ -83,10 +83,10 @@ def live(lrrbot, conn, event, respond_to):
 
 	# Shorter message
 	message = tag + ", ".join([
-		"%s (%s) is playing %s" % (
+		"%s (%s)%s" % (
 			data["stream"]["channel"]["display_name"],
 			data["stream"]["channel"]["url"],
-			data["stream"]["game"],
+			" is playing %s" % data["stream"]["game"] if data["stream"].get("game") is not None else "",
 		) for data in streams
 	])
 	if len(message) <= 450:

--- a/lrrbot/commands/live.py
+++ b/lrrbot/commands/live.py
@@ -1,6 +1,5 @@
 from lrrbot.main import bot
 from lrrbot import twitch
-from lrrbot import storage
 from lrrbot import googlecalendar
 from common import utils
 from common.config import config
@@ -34,13 +33,10 @@ def extract_new_channels(loop):
 						continue
 					channels.add(channel)
 
-	storage.data.setdefault("fan_channels", [])
-	new_channels = list(channels.difference(storage.data["fan_channels"]))
-	channels_data = yield from asyncio.gather(*[twitch.get_stream_info(channel) for channel in new_channels], loop=loop, return_exceptions=True)
-	for channel, data in zip(new_channels, channels_data):
-		if isinstance(data, dict) and "error" not in data:
-			storage.data["fan_channels"].append(channel)
-	storage.save()
+	follows = yield from twitch.get_follows_channels()
+	old_channels = {channel["channel"]["name"] for channel in follows}
+
+	yield from asyncio.gather(*map(twitch.follow_channel, channels.difference(old_channels)), loop=loop, return_exceptions=True)
 
 @bot.command("live")
 @utils.throttle()
@@ -57,25 +53,21 @@ def live(lrrbot, conn, event, respond_to):
 	except urllib.error.HTTPError:
 		pass
 
-	streams = yield from asyncio.gather(*[
-		twitch.get_stream_info(channel)
-		for channel in storage.data.get("fan_channels", [])
-	], loop=lrrbot.loop)
-	streams = [data for data in streams if data.get("stream") is not None]
+	streams = yield from twitch.get_streams_followed()
 	if streams == []:
 		return conn.privmsg(respond_to, "No fanstreamers currently live.")
 
-	streams.sort(key=lambda e: e["stream"]["channel"]["display_name"])
+	streams.sort(key=lambda e: e["channel"]["display_name"])
 
 	tag = "Currently live fanstreamers: "
 
 	# Full message
 	message = tag + ", ".join([
 		"%s (%s)%s%s" % (
-			data["stream"]["channel"]["display_name"],
-			data["stream"]["channel"]["url"],
-			" is playing %s" % data["stream"]["game"] if data["stream"].get("game") is not None else "",
-			" (%s)" % data["stream"]["channel"]["status"] if data["stream"]["channel"].get("status") not in [None, ""] else ""
+			data["channel"]["display_name"],
+			data["channel"]["url"],
+			" is playing %s" % data["game"] if data.get("game") is not None else "",
+			" (%s)" % data["channel"]["status"] if data["channel"].get("status") not in [None, ""] else ""
 		) for data in streams
 	])
 	if len(message) <= 450:
@@ -84,9 +76,9 @@ def live(lrrbot, conn, event, respond_to):
 	# Shorter message
 	message = tag + ", ".join([
 		"%s (%s)%s" % (
-			data["stream"]["channel"]["display_name"],
-			data["stream"]["channel"]["url"],
-			" is playing %s" % data["stream"]["game"] if data["stream"].get("game") is not None else "",
+			data["channel"]["display_name"],
+			data["channel"]["url"],
+			" is playing %s" % data["game"] if data.get("game") is not None else "",
 		) for data in streams
 	])
 	if len(message) <= 450:
@@ -95,14 +87,15 @@ def live(lrrbot, conn, event, respond_to):
 	# Shortest message
 	message = tag + ", ".join([
 		"%s (%s)" % (
-			data["stream"]["channel"]["display_name"],
-			data["stream"]["channel"]["url"]
+			data["channel"]["display_name"],
+			data["channel"]["url"]
 		) for data in streams
 	])
 	return conn.privmsg(respond_to, utils.shorten(message, 450))
 
 
 @bot.command("live register")
+@asyncio.coroutine
 def register_self(lrrbot, conn, event, respond_to):
 	"""
 	Command: !live register
@@ -110,11 +103,12 @@ def register_self(lrrbot, conn, event, respond_to):
 	Register your channel as a fanstreamer channel.
 	"""
 	channel = irc.client.NickMask(event.source).nick.lower()
-	storage.data["fan_channels"] = list(set(storage.data.get("fan_channels", []) + [channel]))
+	yield from twitch.follow_channel(channel)
 	conn.privmsg(respond_to, "Channel '%s' added to the fanstreamer list." % channel)
 
 @bot.command("live register (.*)")
 @utils.mod_only
+@asyncio.coroutine
 def register(lrrbot, conn, event, respond_to, channel):
 	"""
 	Command: !live register CHANNEL
@@ -122,8 +116,7 @@ def register(lrrbot, conn, event, respond_to, channel):
 	Register CHANNEL as a fanstreamer channel.
 	"""
 	try:
-		yield from twitch.get_stream_info(channel)
-		storage.data["fan_channels"] = list(set(storage.data.get("fan_channels", []) + [channel]))
+		yield from twitch.follow_channel(channel)
 		conn.privmsg(respond_to, "Channel '%s' added to the fanstreamer list." % channel)
 	except urllib.error.HTTPError:
 		conn.privmsg(respond_to, "'%s' isn't a Twitch channel." % channel)

--- a/lrrbot/twitch.py
+++ b/lrrbot/twitch.py
@@ -127,8 +127,45 @@ def get_group_servers():
 	random.shuffle(servers)
 	return servers
 
-@utils.cache(5 * 60, params=[0])
 @asyncio.coroutine
-def get_stream_info(channel):
-	data = yield from utils.http_request_coro("https://api.twitch.tv/kraken/streams/%s" % channel)
-	return json.loads(data)
+def get_follows_channels(username=None):
+	if username is None:
+		username = config["username"]
+	url = "https://api.twitch.tv/kraken/users/%s/follows/channels" % username
+	follows = []
+	total = 1
+	while len(follows) < total:
+		data = yield from utils.http_request_coro(url)
+		data = json.loads(data)
+		total = data["_total"]
+		follows += data["follows"]
+		url = data["_links"]["next"]
+	return follows
+
+@asyncio.coroutine
+def get_streams_followed(username=None):
+	if username is None:
+		username = config["username"]
+	url = "https://api.twitch.tv/kraken/streams/followed"
+	headers = {
+		"Authorization": "OAuth %s" % storage.data['twitch_oauth'][username],
+	}
+	streams = []
+	total = 1
+	while len(streams) < total:
+		data = yield from utils.http_request_coro(url, headers=headers)
+		data = json.loads(data)
+		total = data["_total"]
+		streams += data["streams"]
+		url = data["_links"]["next"]
+	return streams
+
+@asyncio.coroutine
+def twitch.follow_channel(target, user=None):
+	if user is None:
+		user = config["username"]
+	headers = {
+		"Authorization": "OAuth %s" % storage.data['twitch_oauth'][user],
+	}
+	yield from utils.http_request_coro("https://api.twitch.tv/kraken/users/%s/follows/channel/%s" % (user, target),
+									data={"notifications": "false"}, method="PUT", headers=headers)

--- a/lrrbot/twitch.py
+++ b/lrrbot/twitch.py
@@ -126,3 +126,9 @@ def get_group_servers():
 	servers = [(host, preferred_port(ports)) for host,ports in server_dict.items()]
 	random.shuffle(servers)
 	return servers
+
+@utils.cache(5 * 60, params=[0])
+@asyncio.coroutine
+def get_stream_info(channel):
+	data = yield from utils.http_request_coro("https://api.twitch.tv/kraken/streams/%s" % channel)
+	return json.loads(data)


### PR DESCRIPTION
New commands to replace the shady link to leg_bot's decaying carcass.
* `!live`: Post the currenly live fanstreamers.
* `!live register`: Register your channel as a fanstreamer channel.
* `!live register CHANNEL`: Register CHANNEL as a fanstreamer channel.

Once a day `!live` checks for new channels in the calendar.

List of channels leg_bot was checking:
```json
[
    "only_scrubs_skip_leg_day",
    "rebelliousuno",
    "cantwearhats",
    "caffeinatedlemur",
    "durugai",
    "rucdoc",
    "vmkid",
    "dix",
    "admiralmemo",
    "mowdownjoe",
    "antitonic",
    "mastercheese",
    "polluxprocyon",
    "hpbraincase",
    "i_am_clockwork",
    "rerout343",
    "boofinka",
    "rednightmare7",
    "lambmower",
    "reilaoda",
    "themoosetetrino",
    "selenes92",
    "ranneko",
    "senstaku",
    "navarran",
    "erockhiphop",
    "uknit",
    "darkmorford",
    "mister_blue_sky",
    "tstodden",

    "seabats",
    "voxlunch",
    "james_lrr",
    "thepettersaga",
    "streambros",
    "darkmorford",
    "nullrush",
    "ekimekim3000",
    "raymonong",
    "lambmower",
    "sohnata",
    "nfstreams",
    "roastedgravy",
    "magistermystax",
    "mistahfixit",
    "j_s_bach",
    "lordwolfwood",
    "doctormia",
    "kinogami",
    "devinsanity",
    "charlofsweden",
    "cattleprodlynn",
    "roosevelt",
    "desertbus",
    "hiramas",
    "featherweight_",
    "rayfk",
    "themoatman",
    "metricos",
    "senstaku",
    "thefilthycasualplays",
    "uknit",
    "navarran",
    "upickvg",
    "malfunct",
    "catcard",
    "elcalen"
]
```
Channels that are on the calendar but not in leg_bot's list:
```json
[
    "v_nome",
    "survivor.tv",
    "survivor_tv",
    "doktornik",
    "koizom",
    "elementalalchemist",
    "kidspanner",
    "shadowchorus",
    "jwiley129",
    "rantling",
    "diserasta"
]
```