### PR TITLE
Link spam

### DIFF
--- a/common/utils.py
+++ b/common/utils.py
@@ -690,3 +690,46 @@ def weighted_choice(options):
 		else:
 			left = mid
 	return values[left]
+
+@cache(60 * 60, params=[0])
+@asyncio.coroutine
+def canonical_url(url, depth=10):
+	if not url.startswith("http://") and not url.startswith("https://"):
+		url = "http://" + url
+	if depth <= 0:
+		return [url]
+	try:
+		res = yield from http_request_coro(url, method="HEAD", allow_redirects=False)
+		if res.status in range(300, 400) and "Location" in res.headers:
+			return [url] + (yield from canonical_url(urllib.parse.urljoin(url, res.headers["Location"], depth - 1)))
+	except Exception:
+		log.exception("Error fetching %r:", url)
+		pass
+	return [url]
+
+@cache(24 * 60 * 60)
+@asyncio.coroutine
+def get_tlds():
+	tlds = set()
+	data = yield from http_request_coro("https://data.iana.org/TLD/tlds-alpha-by-domain.txt")
+	for line in data.splitlines():
+		if not line.startswith("#"):
+			line = line.strip().lower()
+			tlds.add(line)
+			line = line.encode("ascii").decode("idna")
+			tlds.add(line)
+	return tlds
+
+@cache(24 * 60 * 60)
+@asyncio.coroutine
+def url_regex():
+	parens = ["()", "[]", "{}", "<>", '""', "''"]
+
+	# Sort TLDs in decreasing order by length to avoid incorrect matches.
+	# For example: if 'co' is before 'com', 'example.com/path' is matched as 'example.co'.
+	tlds = sorted((yield from get_tlds()), key=lambda e: len(e), reverse=True)
+	re_tld = "(?:" + "|".join(map(re.escape, tlds)) + ")"
+	re_hostname = "(?:(?:(?:[\w-]+\.)+" + re_tld + "\.?)|(?:\d{,3}(?:\.\d{,3}){3})|(?:\[[0-9a-fA-F:.]+\]))"
+	re_url = "((?:https?://)?" + re_hostname + "(?::\d+)?(?:/[\x5E\s\u200b]*)?)"
+	re_url = re_url + "|" + "|".join(map(lambda parens: re.escape(parens[0]) + re_url + re.escape(parens[1]), parens))
+	return re.compile(re_url, re.IGNORECASE)

--- a/common/utils.py
+++ b/common/utils.py
@@ -443,7 +443,7 @@ def http_request(url, data=None, method='GET', maxtries=3, headers={}, timeout=5
 http_request_session = aiohttp.ClientSession(connector=aiohttp.TCPConnector(limit=6))
 atexit.register(http_request_session.close)
 @asyncio.coroutine
-def http_request_coro(url, data=None, method='GET', maxtries=3, headers={}, timeout=5):
+def http_request_coro(url, data=None, method='GET', maxtries=3, headers={}, timeout=5, allow_redirects=True):
 	headers["User-Agent"] = "LRRbot/2.0 (http://lrrbot.mrphlip.com/)"
 	firstex = None
 	if method == 'GET':
@@ -453,7 +453,9 @@ def http_request_coro(url, data=None, method='GET', maxtries=3, headers={}, time
 		params = None
 	while True:
 		try:
-			res = yield from asyncio.wait_for(http_request_session.request(method, url, params=params, data=data, headers=headers), timeout)
+			res = yield from asyncio.wait_for(http_request_session.request(method, url, params=params, data=data, headers=headers, allow_redirects=allow_redirects), timeout)
+			if method == "HEAD":
+				return res
 			status_class = res.status // 100
 			if status_class != 2:
 				yield from res.read()

--- a/common/utils.py
+++ b/common/utils.py
@@ -703,7 +703,7 @@ def canonical_url(url, depth=10):
 		if res.status in range(300, 400) and "Location" in res.headers:
 			return [url] + (yield from canonical_url(urllib.parse.urljoin(url, res.headers["Location"], depth - 1)))
 	except Exception:
-		log.exception("Error fetching %r:", url)
+		log.error("Error fetching %r", url)
 		pass
 	return [url]
 

--- a/lrrbot/linkspam.py
+++ b/lrrbot/linkspam.py
@@ -2,60 +2,22 @@ import asyncio
 import re
 import logging
 from common import utils
-from urllib.parse import urljoin
 from lrrbot import storage
 import irc.client
 
 log = logging.getLogger('linkspam')
 
-PARENS = ["()", "[]", "{}", "<>", '""', "''"]
-
 class LinkSpam:
 	def __init__(self, loop):
-		self.loop = loop
-		
-		tlds = loop.run_until_complete(self.get_tlds())
-		# Sort TLDs in decreasing order by length to avoid incorrect matches.
-		# For example: if 'co' is before 'com', 'example.com/path' is matched as 'example.co'.
-		tlds = sorted(tlds, key=lambda e: len(e), reverse=True)
-		re_tld = "(?:" + "|".join(map(re.escape, tlds)) + ")"
-		re_hostname = "(?:(?:(?:[\w-]+\.)+" + re_tld + "\.?)|(?:\d{,3}(?:\.\d{,3}){3})|(?:\[[0-9a-fA-F:.]+\]))"
-		re_url = "((?:https?://)?" + re_hostname + "(?::\d+)?(?:/[\x5E\s\u200b]*)?)"
-		re_url = re_url + "|" + "|".join(map(lambda parens: re.escape(parens[0]) + re_url + re.escape(parens[1]), PARENS))
-		self._re_url = re.compile(re_url, re.IGNORECASE)
-		self._spam_rules = [
+		self._loop = loop
+		self._re_url = loop.run_until_complete(utils.url_regex())
+		self._rules = [
 			{
 				"re": re.compile(rule["re"], re.IGNORECASE),
 				"message": rule["message"]
 			}
 			for rule in storage.data.get("link_spam_rules", [])
 		]
-
-	@asyncio.coroutine
-	def get_tlds(self):
-		tlds = set()
-		data = yield from utils.http_request_coro("https://data.iana.org/TLD/tlds-alpha-by-domain.txt")
-		for line in data.splitlines():
-			if not line.startswith("#"):
-				line = line.strip().lower()
-				tlds.add(line)
-				line = line.encode("ascii").decode("idna")
-				tlds.add(line)
-		return tlds
-
-	@utils.cache(60 * 60, params=[1])
-	@asyncio.coroutine
-	def canonical_url(self, url):
-		if not url.startswith("http://") and not url.startswith("https://"):
-			url = "http://" + url
-		try:
-			res = yield from utils.http_request_coro(url, method="HEAD", allow_redirects=False)
-			if res.status in range(300, 400) and "Location" in res.headers:
-				return [url] + (yield from self.canonical_url(urljoin(url, res.headers["Location"])))
-		except Exception:
-			log.exception("Error fetching %r:", url)
-			pass
-		return [url]
 
 	@asyncio.coroutine
 	def check_urls(self, conn, event, message):
@@ -65,7 +27,7 @@ class LinkSpam:
 				if url is not None:
 					urls.append(url)
 					break
-		canonical_urls = yield from asyncio.gather(*map(self.canonical_url, urls), loop=self.loop)
+		canonical_urls = yield from asyncio.gather(*map(utils.canonical_url, urls), loop=self._loop)
 		for original_url, url_chain in zip(urls, canonical_urls):
 			for url in url_chain:
 				for rule in self._rules:

--- a/lrrbot/linkspam.py
+++ b/lrrbot/linkspam.py
@@ -14,9 +14,21 @@ class LinkSpam:
 		self._rules = [
 			{
 				"re": re.compile(rule["re"], re.IGNORECASE),
-				"message": rule["message"]
+				"message": rule["message"],
 			}
 			for rule in storage.data.get("link_spam_rules", [])
+		]
+		self.add_server_event("modify_link_spam_rules", self.modify_link_spam_rules)
+
+	def modify_link_spam_rules(self, lrrbot, user, data):
+		storage.data['link_spam_rules'] = data
+		storage.save()
+		self._rules = [
+			{
+				"re": re.compile(rule['re'], re.IGNORECASE),
+				"message": rule['message'],
+			}
+			for rule in storage.data['link_spam_rules']
 		]
 
 	@asyncio.coroutine

--- a/lrrbot/linkspam.py
+++ b/lrrbot/linkspam.py
@@ -1,0 +1,78 @@
+import asyncio
+import re
+import logging
+from common import utils
+from urllib.parse import urljoin
+from lrrbot import storage
+import irc.client
+
+log = logging.getLogger('linkspam')
+
+PARENS = ["()", "[]", "{}", "<>", '""', "''"]
+
+class LinkSpam:
+	def __init__(self, loop):
+		self.loop = loop
+		
+		tlds = loop.run_until_complete(self.get_tlds())
+		# Sort TLDs in decreasing order by length to avoid incorrect matches.
+		# For example: if 'co' is before 'com', 'example.com/path' is matched as 'example.co'.
+		tlds = sorted(tlds, key=lambda e: len(e), reverse=True)
+		re_tld = "(?:" + "|".join(map(re.escape, tlds)) + ")"
+		re_hostname = "(?:(?:(?:[\w-]+\.)+" + re_tld + "\.?)|(?:\d{,3}(?:\.\d{,3}){3})|(?:\[[0-9a-fA-F:.]+\]))"
+		re_url = "((?:https?://)?" + re_hostname + "(?::\d+)?(?:/[\x5E\s\u200b]*)?)"
+		re_url = re_url + "|" + "|".join(map(lambda parens: re.escape(parens[0]) + re_url + re.escape(parens[1]), PARENS))
+		self._re_url = re.compile(re_url, re.IGNORECASE)
+		self._spam_rules = [
+			{
+				"re": re.compile(rule["re"], re.IGNORECASE),
+				"message": rule["message"]
+			}
+			for rule in storage.data.get("link_spam_rules", [])
+		]
+
+	@asyncio.coroutine
+	def get_tlds(self):
+		tlds = set()
+		data = yield from utils.http_request_coro("https://data.iana.org/TLD/tlds-alpha-by-domain.txt")
+		for line in data.splitlines():
+			if not line.startswith("#"):
+				line = line.strip().lower()
+				tlds.add(line)
+				line = line.encode("ascii").decode("idna")
+				tlds.add(line)
+		return tlds
+
+	@utils.cache(60 * 60, params=[1])
+	@asyncio.coroutine
+	def canonical_url(self, url):
+		if not url.startswith("http://") and not url.startswith("https://"):
+			url = "http://" + url
+		try:
+			res = yield from utils.http_request_coro(url, method="HEAD", allow_redirects=False)
+			if res.status in range(300, 400) and "Location" in res.headers:
+				return [url] + (yield from self.canonical_url(urljoin(url, res.headers["Location"])))
+		except Exception:
+			log.exception("Error fetching %r:", url)
+			pass
+		return [url]
+
+	@asyncio.coroutine
+	def check_urls(self, conn, event, message):
+		urls = []
+		for match in self._re_url.finditer(message):
+			for url in match.groups():
+				if url is not None:
+					urls.append(url)
+					break
+		canonical_urls = yield from asyncio.gather(*map(self.canonical_url, urls), loop=self.loop)
+		for original_url, url_chain in zip(urls, canonical_urls):
+			for url in url_chain:
+				for rule in self._rules:
+					match = rule["re"].search(url)
+					if match is not None:
+						source = irc.client.NickMask(event.source)
+						log.info("Detected link spam from %s - %r contains the URL %r which redirects to %r which matches %r",
+							source.nick, message, original_url, url, rule["re"].pattern)
+						self.ban(conn, event, rule["message"] % {str(i+1): v for i, v in enumerate(match.groups())})
+						return

--- a/lrrbot/main.py
+++ b/lrrbot/main.py
@@ -42,7 +42,6 @@ class LRRBot(irc.bot.SingleServerIRCBot, linkspam.LinkSpam):
 			nickname=config['username'],
 			reconnection_interval=config['reconnecttime'],
 		)
-		linkspam.LinkSpam.__init__(self, loop)
 
 		# Send a keep-alive message every minute, to catch network dropouts
 		# self.connection has a set_keepalive method, but it crashes
@@ -95,6 +94,8 @@ class LRRBot(irc.bot.SingleServerIRCBot, linkspam.LinkSpam):
 		self.mods = set(storage.data.get('mods', config['mods']))
 		self.subs = set(storage.data.get('subs', []))
 		self.autostatus = set(storage.data.get('autostatus', []))
+
+		linkspam.LinkSpam.__init__(self, loop)
 
 	def reactor_class(self):
 		return asyncreactor.AsyncReactor(self.loop)

--- a/lrrbot/main.py
+++ b/lrrbot/main.py
@@ -19,14 +19,14 @@ import irc.modes
 
 from common import utils
 from common.config import config
-from lrrbot import chatlog, storage, twitch, twitchsubs, whisper, asyncreactor
+from lrrbot import chatlog, storage, twitch, twitchsubs, whisper, asyncreactor, linkspam
 
 
 log = logging.getLogger('lrrbot')
 
 SELF_METADATA = {'specialuser': {'mod', 'subscriber'}, 'usercolor': '#FF0000', 'emoteset': {317}}
 
-class LRRBot(irc.bot.SingleServerIRCBot):
+class LRRBot(irc.bot.SingleServerIRCBot, linkspam.LinkSpam):
 	GAME_CHECK_INTERVAL = 5*60 # Only check the current game at most once every five minutes
 
 	def __init__(self, loop):
@@ -42,6 +42,7 @@ class LRRBot(irc.bot.SingleServerIRCBot):
 			nickname=config['username'],
 			reconnection_interval=config['reconnecttime'],
 		)
+		linkspam.LinkSpam.__init__(self, loop)
 
 		# Send a keep-alive message every minute, to catch network dropouts
 		# self.connection has a set_keepalive method, but it crashes
@@ -250,6 +251,7 @@ class LRRBot(irc.bot.SingleServerIRCBot):
 		elif self.check_spam(conn, event, event.arguments[0]):
 			return
 		else:
+			asyncio.async(self.check_urls(conn, event, event.arguments[0]), loop=self.loop).add_done_callback(utils.check_exception)
 			if self.access == "mod" and not self.is_mod(event):
 				return
 			if self.access == "sub" and not self.is_mod(event) and not self.is_sub(event):
@@ -399,43 +401,49 @@ class LRRBot(irc.bot.SingleServerIRCBot):
 	def is_sub_nick(self, nick):
 		return nick.lower() in self.subs
 
+	def ban(self, conn, event, reason):
+		source = irc.client.NickMask(event.source)
+		self.spammers.setdefault(source.nick.lower(), 0)
+		self.spammers[source.nick.lower()] += 1
+		level = self.spammers[source.nick.lower()]
+		if level <= 1:
+			log.info("First offence, flickering %s" % source.nick)
+			conn.privmsg(event.target, ".timeout %s 1" % source.nick)
+			conn.privmsg(event.target, "%s: Message deleted (first warning) for auto-detected spam (%s). Please contact mrphlip or d3fr0st5 if this is incorrect." % (source.nick, reason))
+		elif level <= 2:
+			log.info("Second offence, timing out %s" % source.nick)
+			conn.privmsg(event.target, ".timeout %s" % source.nick)
+			conn.privmsg(event.target, "%s: Timeout (second warning) for auto-detected spam (%s). Please contact mrphlip or d3fr0st5 if this is incorrect." % (source.nick, reason))
+		else:
+			log.info("Third offence, banning %s" % source.nick)
+			conn.privmsg(event.target, ".ban %s" % source.nick)
+			conn.privmsg(event.target, "%s: Banned for persistent spam (%s). Please contact mrphlip or d3fr0st5 if this is incorrect." % (source.nick, reason))
+			level = 3
+		today = datetime.datetime.now(config['timezone']).date().toordinal()
+		if today != storage.data.get("spam",{}).get("date"):
+			storage.data["spam"] = {
+				"date": today,
+				"count": [0, 0, 0],
+		}
+		storage.data["spam"]["count"][level - 1] += 1
+		storage.save()
+
 	def check_spam(self, conn, event, message):
 		"""Check the message against spam detection rules"""
 		if not irc.client.is_channel(event.target):
 			return False
 		respond_to = event.target
 		source = irc.client.NickMask(event.source)
+
 		for re, desc in self.spam_rules:
 			matches = re.search(message)
 			if matches:
 				log.info("Detected spam from %s - %r matches %s" % (source.nick, message, re.pattern))
 				groups = {str(i+1):v for i,v in enumerate(matches.groups())}
 				desc = desc % groups
-				self.spammers.setdefault(source.nick.lower(), 0)
-				self.spammers[source.nick.lower()] += 1
-				level = self.spammers[source.nick.lower()]
-				if level <= 1:
-					log.info("First offence, flickering %s" % source.nick)
-					conn.privmsg(event.target, ".timeout %s 1" % source.nick)
-					conn.privmsg(event.target, "%s: Message deleted (first warning) for auto-detected spam (%s). Please contact mrphlip or d3fr0st5 if this is incorrect." % (source.nick, desc))
-				elif level <= 2:
-					log.info("Second offence, timing out %s" % source.nick)
-					conn.privmsg(event.target, ".timeout %s" % source.nick)
-					conn.privmsg(event.target, "%s: Timeout (second warning) for auto-detected spam (%s). Please contact mrphlip or d3fr0st5 if this is incorrect." % (source.nick, desc))
-				else:
-					log.info("Third offence, banning %s" % source.nick)
-					conn.privmsg(event.target, ".ban %s" % source.nick)
-					conn.privmsg(event.target, "%s: Banned for persistent spam (%s). Please contact mrphlip or d3fr0st5 if this is incorrect." % (source.nick, desc))
-					level = 3
-				today = datetime.datetime.now(config['timezone']).date().toordinal()
-				if today != storage.data.get("spam",{}).get("date"):
-					storage.data["spam"] = {
-						"date": today,
-						"count": [0, 0, 0],
-				}
-				storage.data["spam"]["count"][level - 1] += 1
-				storage.save()
+				self.ban(conn, event, desc)
 				return True
+
 		return False
 
 	def rpc_server(self):

--- a/lrrbot/main.py
+++ b/lrrbot/main.py
@@ -403,21 +403,23 @@ class LRRBot(irc.bot.SingleServerIRCBot, linkspam.LinkSpam):
 
 	def ban(self, conn, event, reason):
 		source = irc.client.NickMask(event.source)
+		tags = dict((i['key'], i['value']) for i in event.tags)
+		display_name = tags.get("display_name") or source.nick
 		self.spammers.setdefault(source.nick.lower(), 0)
 		self.spammers[source.nick.lower()] += 1
 		level = self.spammers[source.nick.lower()]
 		if level <= 1:
-			log.info("First offence, flickering %s" % source.nick)
+			log.info("First offence, flickering %s" % display_name)
 			conn.privmsg(event.target, ".timeout %s 1" % source.nick)
-			conn.privmsg(event.target, "%s: Message deleted (first warning) for auto-detected spam (%s). Please contact mrphlip or d3fr0st5 if this is incorrect." % (source.nick, reason))
+			conn.privmsg(event.target, "%s: Message deleted (first warning) for auto-detected spam (%s). Please contact mrphlip or d3fr0st5 if this is incorrect." % (display_name, reason))
 		elif level <= 2:
-			log.info("Second offence, timing out %s" % source.nick)
+			log.info("Second offence, timing out %s" % display_name)
 			conn.privmsg(event.target, ".timeout %s" % source.nick)
-			conn.privmsg(event.target, "%s: Timeout (second warning) for auto-detected spam (%s). Please contact mrphlip or d3fr0st5 if this is incorrect." % (source.nick, reason))
+			conn.privmsg(event.target, "%s: Timeout (second warning) for auto-detected spam (%s). Please contact mrphlip or d3fr0st5 if this is incorrect." % (display_name, reason))
 		else:
-			log.info("Third offence, banning %s" % source.nick)
+			log.info("Third offence, banning %s" % display_name)
 			conn.privmsg(event.target, ".ban %s" % source.nick)
-			conn.privmsg(event.target, "%s: Banned for persistent spam (%s). Please contact mrphlip or d3fr0st5 if this is incorrect." % (source.nick, reason))
+			conn.privmsg(event.target, "%s: Banned for persistent spam (%s). Please contact mrphlip or d3fr0st5 if this is incorrect." % (display_name, reason))
 			level = 3
 		today = datetime.datetime.now(config['timezone']).date().toordinal()
 		if today != storage.data.get("spam",{}).get("date"):

--- a/webserver.py
+++ b/webserver.py
@@ -27,4 +27,4 @@ app.jinja_env.globals["max"] = max
 __all__ = ['app']
 
 if __name__ == '__main__':
-	app.run(debug=True)
+	app.run(debug=True, use_reloader=False)

--- a/www/botinteract.py
+++ b/www/botinteract.py
@@ -64,6 +64,9 @@ def modify_spam_rules(data):
 	"""
 	send_bot_command("modify_spam_rules", data)
 
+def modify_link_spam_rules(data):
+	send_bot_command("modify_link_spam_rules", data)
+
 def get_commands():
 	return send_bot_command("get_commands", None)
 

--- a/www/static/spam.js
+++ b/www/static/spam.js
@@ -5,6 +5,9 @@ function init()
 	$('div.button.add').click(addRow);
 	$('div.button.remove').click(deleteRow);
 
+	if (window.link_spam)
+		$('button.redirects').click(redirects);
+
 	fixRows();
 }
 $(init);
@@ -80,7 +83,8 @@ function save()
 	$.ajax({
 		'type': 'POST',
 		'url': "spam/submit",
-		'data': "data=" + encodeURIComponent(data) + "&_csrf_token=" + encodeURIComponent(window.csrf_token),
+		'data': "data=" + encodeURIComponent(data) + "&_csrf_token=" + encodeURIComponent(window.csrf_token) +
+			(window.link_spam ? "&link_spam" : ""),
 		'dataType': 'json',
 		'async': true,
 		'cache': false,
@@ -98,12 +102,37 @@ function test()
 	$.ajax({
 		'type': 'POST',
 		'url': "spam/test",
-		'data': "data=" + encodeURIComponent(data) + "&message=" + encodeURIComponent(message) + "&_csrf_token=" + encodeURIComponent(window.csrf_token),
+		'data': "data=" + encodeURIComponent(data) + "&message=" + encodeURIComponent(message) +
+			"&_csrf_token=" + encodeURIComponent(window.csrf_token) + (window.link_spam ? "&link_spam" : ""),
 		'dataType': 'json',
 		'async': true,
 		'cache': false,
 		'success': testSuccess,
 		'error': testError
+	});
+}
+
+function redirects()
+{
+	var url = $("input.redirects").val();
+	$.ajax({
+		'type': 'GET',
+		'url': "spam/redirects",
+		'data': "url=" + encodeURIComponent(url) + "&_csrf_token=" + encodeURIComponent(window.csrf_token),
+		'dataType': 'json',
+		'async': true,
+		'success': function(data) {
+			window.csrf_token = data["csrf_token"];
+			var urls = data["redirects"];
+			var container = $("ol.redirects");
+			container.empty();
+			for (var i = 0; i < urls.length; i++) {
+				container.append("<li><a href=\"" + urls[i] + "\">" + urls[i] + "</a></li>");
+			}
+		},
+		'error': function(error) {
+			alert("Error fetching redirects");
+		}
 	});
 }
 

--- a/www/templates/spam.html
+++ b/www/templates/spam.html
@@ -2,11 +2,23 @@
 {%block title%}Spam Rules{%endblock%}
 {%block header%}Spam Rules{%endblock%}
 {%block headextra%}
-<script type="text/javascript">window.csrf_token = {{csrf_token()|tojson}}</script>
+<script type="text/javascript">
+    window.csrf_token = {{csrf_token()|tojson}};
+    window.link_spam = {{link_spam|tojson}};
+</script>
 <script type="text/javascript" src="{{url_for('static', filename='spam.js')|e}}"></script>
 {%endblock%}
 {%block content%}
-<p><a href="{{url_for('spam_find')|e}}">Find potential spambots</a></p>
+<ol class="menu">
+	<li class="first">
+		{% if link_spam %}
+			<strong>Link spam rules</strong>
+		{% else %}
+			<a href="{{url_for('spam', link_spam='')|e}}">Link spam rules</a>
+		{% endif %}
+	</li>
+	<li><a href="{{url_for('spam_find')|e}}">Find potential spambots</a></li>
+</ol>
 <div style="text-align:right; margin: 1em">
 	<button class="save">Save</button>
 	<div class="save loading" style="display: none; margin: 0 0 0 auto"></div>
@@ -44,6 +56,13 @@
 </tr>
 </tfoot>
 </table>
+
+{% if link_spam %}
+<h2>Follow redirects</h2>
+<p><input type="text" class="redirects"> <button class="redirects">Follow redirects</button></p>
+<ol class="redirects"></ol>
+{% endif %}
+
 <h2>Testing area</h2>
 <p>Copy text here from the chat to test out the spam rules, before saving them!</p>
 <div><textarea style="width: 100%; height: 5em" id="testtext"></textarea></div>


### PR DESCRIPTION
Werkzeug reloader disabled because it uses threads but `aiohttp`'s sessions aren't thread-safe.

"Find potential spambots" page doesn't check for spam links yet.