### PR TITLE
Adding permit command and link whitelist. 

### DIFF
--- a/lrrbot/commands/misc.py
+++ b/lrrbot/commands/misc.py
@@ -38,6 +38,24 @@ def stormcount(lrrbot, conn, event, respond_to):
 		storage.save()
 	conn.privmsg(respond_to, "Today's storm count: %d" % storage.data["storm"]["count"])
 	
+@bot.command("permit")
+@utils.throttle()
+def permit(lrrbot, conn, event, respond_to):
+	"""
+	Command: !permit
+	Section: misc
+
+	Adds requesting user to whitelist, only works if this is a private message.
+	"""
+	#ignore command unless it's a private message
+	if event.type not "privmsg":
+		return
+	if lrrbot.allowed_to_link(respond_to.lower()):
+		conn.privmsg(respond_to, "You are already able to post links")
+	else:
+		conn.privmsg(respond_to, "I'll let you post links but use this power wisely, the mods may yet strike you down.")
+		lrrbot.whitelist.push(respond_to.lower())
+
 @bot.command("spam(?:count)?")
 @utils.throttle()
 def spamcount(lrrbot, conn, event, respond_to):

--- a/lrrbot/storage.py
+++ b/lrrbot/storage.py
@@ -34,6 +34,11 @@ data = {
 			'message': '<ban description>',
 		},
 	],
+	'link_rules': [
+		{
+			're': '<regular expression>'
+		}
+	],
 }
 
 For example:


### PR DESCRIPTION
You will need to update data.json with link_rules, regex to see if something is a link or not.

Changes to main.py, misc.py and storage.py (the last is just documentation of the link_rules regex)

in main.py I have added a stage of checking input to see if there is a link in the message and some more methods to check to see if the user is allowed to post links (if they are a mod, a sub or have requested to be put on the whitelist). For convenience I also abstracted out the mark-as-spammer logic so it could be used in both checking for spam and checking for links. May be a bit OTT but seemed appropriate.

in misc.py I have added the !permit command that only works over privMsg's, You're welcome to add the !noticemesenpai command synonym if you want but it was probably a bit long ;)