### PR TITLE
Remove `utils.http_request`

### DIFF
--- a/common/gdata.py
+++ b/common/gdata.py
@@ -43,7 +43,7 @@ def get_oauth_token(scopes):
 
 	data = {"grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer", "assertion": jwt}
 
-	ret = json.loads((yield from utils.http_request_coro("https://accounts.google.com/o/oauth2/token", data, "POST")))
+	ret = json.loads((yield from utils.http_request("https://accounts.google.com/o/oauth2/token", data, "POST")))
 	if "error" in ret:
 		raise Exception(ret["error"])
 	return ret
@@ -64,12 +64,12 @@ def add_rows_to_spreadsheet(spreadsheet, rows):
 	token = yield from get_oauth_token(["https://spreadsheets.google.com/feeds"])
 	headers = {"Authorization": "%(token_type)s %(access_token)s" % token}
 	url = "https://spreadsheets.google.com/feeds/worksheets/%s/private/full" % spreadsheet
-	tree = xml.dom.minidom.parseString((yield from utils.http_request_coro(url, headers=headers)))
+	tree = xml.dom.minidom.parseString((yield from utils.http_request(url, headers=headers)))
 	worksheet = next(iter(tree.getElementsByTagName("entry")))
 	list_feed = find_schema(worksheet, "http://schemas.google.com/spreadsheets/2006#listfeed")
 	if list_feed is None:
 		raise Exception("List feed missing.")
-	list_feed = xml.dom.minidom.parseString((yield from utils.http_request_coro(list_feed, headers=headers)))
+	list_feed = xml.dom.minidom.parseString((yield from utils.http_request(list_feed, headers=headers)))
 	post_url = find_schema(list_feed, "http://schemas.google.com/g/2005#post")
 	if post_url is None:
 		raise Exception("POST URL missing.")
@@ -83,4 +83,4 @@ def add_rows_to_spreadsheet(spreadsheet, rows):
 			root.appendChild(new_field(doc, column, value))
 
 		headers["Content-Type"] = "application/atom+xml"
-		yield from utils.http_request_coro(post_url, headers=headers, data=doc.toxml(), method="POST")
+		yield from utils.http_request(post_url, headers=headers, data=doc.toxml(), method="POST")

--- a/common/utils.py
+++ b/common/utils.py
@@ -412,7 +412,7 @@ class Request(urllib.request.Request):
 http_request_session = aiohttp.ClientSession(connector=aiohttp.TCPConnector(limit=6))
 atexit.register(http_request_session.close)
 @asyncio.coroutine
-def http_request_coro(url, data=None, method='GET', maxtries=3, headers={}, timeout=5, allow_redirects=True):
+def http_request(url, data=None, method='GET', maxtries=3, headers={}, timeout=5, allow_redirects=True):
 	headers["User-Agent"] = "LRRbot/2.0 (https://lrrbot.mrphlip.com/)"
 	firstex = None
 
@@ -453,9 +453,9 @@ def http_request_coro(url, data=None, method='GET', maxtries=3, headers={}, time
 	raise firstex
 
 @asyncio.coroutine
-def api_request_coro(uri, *args, **kwargs):
+def api_request(uri, *args, **kwargs):
 	try:
-		res = yield from http_request_coro(config.config['siteurl'] + uri, *args, **kwargs)
+		res = yield from http_request(config.config['siteurl'] + uri, *args, **kwargs)
 	except:
 		log.exception("Error at server in %s" % uri)
 	else:
@@ -662,7 +662,7 @@ def canonical_url(url, depth=10):
 	if depth <= 0:
 		return [url]
 	try:
-		res = yield from http_request_coro(url, method="HEAD", allow_redirects=False)
+		res = yield from http_request(url, method="HEAD", allow_redirects=False)
 		if res.status in range(300, 400) and "Location" in res.headers:
 			return [url] + (yield from canonical_url(urllib.parse.urljoin(url, res.headers["Location"], depth - 1)))
 	except Exception:
@@ -674,7 +674,7 @@ def canonical_url(url, depth=10):
 @asyncio.coroutine
 def get_tlds():
 	tlds = set()
-	data = yield from http_request_coro("https://data.iana.org/TLD/tlds-alpha-by-domain.txt")
+	data = yield from http_request("https://data.iana.org/TLD/tlds-alpha-by-domain.txt")
 	for line in data.splitlines():
 		if not line.startswith("#"):
 			line = line.strip().lower()

--- a/highlights.py
+++ b/highlights.py
@@ -44,7 +44,7 @@ def lookup_video(highlight, videos):
 
 @asyncio.coroutine
 def main():
-	if twitch.get_info()["live"]:
+	if (yield from twitch.get_info())["live"]:
 		print("Stream is live.")
 		return
 

--- a/lrrbot/chatlog.py
+++ b/lrrbot/chatlog.py
@@ -236,7 +236,7 @@ def build_message_html(time, source, target, message, specialuser, usercolor, em
 @asyncio.coroutine
 def get_display_name(nick):
 	try:
-		data = yield from utils.http_request_coro("https://api.twitch.tv/kraken/users/%s" % nick)
+		data = yield from utils.http_request("https://api.twitch.tv/kraken/users/%s" % nick)
 		data = json.loads(data)
 		return data['display_name']
 	except:
@@ -246,7 +246,7 @@ re_just_words = re.compile("^\w+$")
 @utils.cache(CACHE_EXPIRY)
 @asyncio.coroutine
 def get_twitch_emotes():
-	data = yield from utils.http_request_coro("https://api.twitch.tv/kraken/chat/emoticons")
+	data = yield from utils.http_request("https://api.twitch.tv/kraken/chat/emoticons")
 	data = json.loads(data)['emoticons']
 	emotesets = {}
 	for emote in data:
@@ -269,7 +269,7 @@ def get_twitch_emotes():
 @asyncio.coroutine
 def get_twitch_emotes_undocumented():
 	# This endpoint is not documented, however `/chat/emoticons` might be deprecated soon.
-	data = yield from utils.http_request_coro("https://api.twitch.tv/kraken/chat/emoticon_images")
+	data = yield from utils.http_request("https://api.twitch.tv/kraken/chat/emoticon_images")
 	data = json.loads(data)["emoticons"]
 	emotesets = {}
 	for emote in data:

--- a/lrrbot/commands/game.py
+++ b/lrrbot/commands/game.py
@@ -1,3 +1,4 @@
+import asyncio
 import irc
 
 from common import utils
@@ -11,6 +12,7 @@ def game_name(game):
 
 @bot.command("game")
 @utils.throttle()
+@asyncio.coroutine
 def current_game(lrrbot, conn, event, respond_to):
 	"""
 	Command: !game
@@ -18,7 +20,7 @@ def current_game(lrrbot, conn, event, respond_to):
 
 	Post the game currently being played.
 	"""
-	game = lrrbot.get_current_game()
+	game = yield from lrrbot.get_current_game()
 	if game is None:
 		message = "Not currently playing any game"
 	else:
@@ -31,6 +33,7 @@ def current_game(lrrbot, conn, event, respond_to):
 	conn.privmsg(respond_to, message)
 
 @bot.command("game (?:(good|yes|:\)|:D|<3|lrrAWESOME|lrrGOAT|lrrSPOT)|(bad|no|:\(|:/|>\(|lrrAWW|lrrEFF|lrrFRUMP))")
+@asyncio.coroutine
 def vote(lrrbot, conn, event, respond_to, vote_good, vote_bad):
 	"""
 	Command: !game good
@@ -42,7 +45,7 @@ def vote(lrrbot, conn, event, respond_to, vote_good, vote_bad):
 	host may heed this or ignore it at their choice. Probably ignore
 	it.
 	"""
-	game = lrrbot.get_current_game(readonly=False)
+	game = yield from lrrbot.get_current_game(readonly=False)
 	if game is None:
 		conn.privmsg(respond_to, "Not currently playing any game")
 		return
@@ -65,6 +68,7 @@ def vote_respond(lrrbot, conn, respond_to, game):
 
 @bot.command("game display (.*?)")
 @utils.mod_only
+@asyncio.coroutine
 def set_game_name(lrrbot, conn, event, respond_to, name):
 	"""
 	Command: !game display NAME
@@ -74,7 +78,7 @@ def set_game_name(lrrbot, conn, event, respond_to, name):
 
 	Change the display name of the current game to NAME.
 	"""
-	game = lrrbot.get_current_game(readonly=False)
+	game = yield from lrrbot.get_current_game(readonly=False)
 	if game is None:
 		conn.privmsg(respond_to, "Not currently playing any game, if they are yell at them to update the stream")
 		return
@@ -84,6 +88,7 @@ def set_game_name(lrrbot, conn, event, respond_to, name):
 
 @bot.command("game override (.*?)")
 @utils.mod_only
+@asyncio.coroutine
 def override_game(lrrbot, conn, event, respond_to, game):
 	"""
 	Command: !game override NAME
@@ -108,7 +113,7 @@ def override_game(lrrbot, conn, event, respond_to, game):
 		operation = "enabled"
 	lrrbot.get_current_game_real.reset_throttle()
 	current_game.reset_throttle()
-	game = lrrbot.get_current_game()
+	game = yield from lrrbot.get_current_game()
 	message = "Override %s. " % operation
 	if game is None:
 		message += "Not currently playing any game"
@@ -118,6 +123,7 @@ def override_game(lrrbot, conn, event, respond_to, game):
 
 @bot.command("game refresh")
 @utils.mod_only
+@asyncio.coroutine
 def refresh(lrrbot, conn, event, respond_to):
 	"""
 	Command: !game refresh
@@ -127,11 +133,12 @@ def refresh(lrrbot, conn, event, respond_to):
 	"""
 	lrrbot.get_current_game_real.reset_throttle()
 	current_game.reset_throttle()
-	current_game(lrrbot, conn, event, respond_to)
+	yield from current_game(lrrbot, conn, event, respond_to)
 
 @bot.command("game completed")
 @utils.mod_only
 @utils.throttle(30, notify=utils.Visibility.PUBLIC, modoverride=False, allowprivate=False)
+@asyncio.coroutine
 def completed(lrrbot, conn, event, respond_to):
 	"""
 	Command: !game completed
@@ -139,7 +146,7 @@ def completed(lrrbot, conn, event, respond_to):
 
 	Mark a game as having been completed.
 	"""
-	game = lrrbot.get_current_game(readonly=False)
+	game = yield from lrrbot.get_current_game(readonly=False)
 	if game is None:
 		conn.privmsg(respond_to, "Not currently playing any game")
 		return

--- a/lrrbot/commands/highlights.py
+++ b/lrrbot/commands/highlights.py
@@ -26,7 +26,7 @@ def highlight(lrrbot, conn, event, respond_to, description):
 	For use when something particularly awesome happens onstream, adds an entry on the Highlight Reel spreadsheet: https://docs.google.com/spreadsheets/d/1yrf6d7dPyTiWksFkhISqEc-JR71dxZMkUoYrX4BR40Y
 	"""
 
-	stream_info = twitch.get_info()
+	stream_info = yield from twitch.get_info()
 	if not stream_info["live"]:
 		conn.privmsg(respond_to, "Not currently streaming.")
 		return

--- a/lrrbot/commands/live.py
+++ b/lrrbot/commands/live.py
@@ -12,7 +12,7 @@ import irc.client
 @utils.cache(24 * 60 * 60)
 @asyncio.coroutine
 def extract_new_channels(loop):
-	data = yield from utils.http_request_coro(googlecalendar.EVENTS_URL % urllib.parse.quote(googlecalendar.CALENDAR_FAN), {
+	data = yield from utils.http_request(googlecalendar.EVENTS_URL % urllib.parse.quote(googlecalendar.CALENDAR_FAN), {
 		"key": config["google_key"],
 		"maxResults": 25000,
 	})

--- a/lrrbot/commands/misc.py
+++ b/lrrbot/commands/misc.py
@@ -141,7 +141,7 @@ def time24(lrrbot, conn, event, respond_to):
 	conn.privmsg(respond_to, "Current moonbase time: %s" % now.strftime("%H:%M"))
 
 @bot.command("viewers")
-@utils.throttle(30) # longer cooldown as this involves 2 API calls
+@utils.throttle()
 def viewers(lrrbot, conn, event, respond_to):
 	"""
 	Command: !viewers
@@ -155,11 +155,7 @@ def viewers(lrrbot, conn, event, respond_to):
 	else:
 		viewers = None
 
-	# Since we're using TWITCHCLIENT 3, we don't get join/part messages, so we can't just use
-	# len(lrrbot.channels["#loadingreadyrun"].userdict)
-	# as that dict won't be populated. Need to call this api instead.
-	chatters = utils.http_request("https://tmi.twitch.tv/group/user/%s/chatters" % config["channel"])
-	chatters = json.loads(chatters).get("chatter_count")
+	chatters = len(lrrbot.channels["#" + config["channel"]].userdict)
 
 	if viewers is not None:
 		viewers = "%d %s viewing the stream." % (viewers, "user" if viewers == 1 else "users")

--- a/lrrbot/commands/strawpoll.py
+++ b/lrrbot/commands/strawpoll.py
@@ -18,7 +18,7 @@ def check_polls(lrrbot, conn):
 	for end, title, poll_id, respond_to in lrrbot.polls:
 		if end < now:
 			url = "https://strawpoll.me/api/v2/polls/%s" % poll_id
-			data = json.loads((yield from utils.http_request_coro(url)))
+			data = json.loads((yield from utils.http_request(url)))
 			options = sorted(zip(data["options"], data["votes"]), key=lambda e: (e[1], random.random()), reverse=True)
 			options = "; ".join(map(strawpoll_format, enumerate(options)))
 			response = "Poll complete: %s: %s" % (data["title"], options)
@@ -58,7 +58,7 @@ def new_poll(lrrbot, conn, event, respond_to, multi, timeout, poll_id, title, op
 	"""
 	if poll_id is not None:
 		url = "https://strawpoll.me/api/v2/polls/%s" % poll_id
-		data = json.loads((yield from utils.http_request_coro(url)))
+		data = json.loads((yield from utils.http_request(url)))
 		title = data["title"]
 	else:
 		if title is None:
@@ -70,7 +70,7 @@ def new_poll(lrrbot, conn, event, respond_to, multi, timeout, poll_id, title, op
 		else:
 			options = options.split()
 		data = json.dumps({"options": options, "title": title, "multi": multi is not None})
-		response = yield from utils.http_request_coro("https://strawpoll.me/api/v2/polls", data, "POST", headers = {"Content-Type": "application/json"})
+		response = yield from utils.http_request("https://strawpoll.me/api/v2/polls", data, "POST", headers = {"Content-Type": "application/json"})
 		poll_id = json.loads(response)["id"]
 	if timeout is not None:
 		timeout = int(timeout)

--- a/lrrbot/commands/strawpoll.py
+++ b/lrrbot/commands/strawpoll.py
@@ -1,6 +1,7 @@
 import time
 import json
 import random
+import asyncio
 
 from common import utils
 from lrrbot.main import bot
@@ -11,12 +12,13 @@ def strawpoll_format(data):
 	i, (name, count) = data
 	return "%s: %s (%d vote%s)" % (i+1, name, count, '' if count == 1 else 's')
 
+@asyncio.coroutine
 def check_polls(lrrbot, conn):
 	now = time.time()
 	for end, title, poll_id, respond_to in lrrbot.polls:
 		if end < now:
 			url = "https://strawpoll.me/api/v2/polls/%s" % poll_id
-			data = json.loads(utils.http_request(url))
+			data = json.loads((yield from utils.http_request_coro(url)))
 			options = sorted(zip(data["options"], data["votes"]), key=lambda e: (e[1], random.random()), reverse=True)
 			options = "; ".join(map(strawpoll_format, enumerate(options)))
 			response = "Poll complete: %s: %s" % (data["title"], options)
@@ -43,6 +45,7 @@ def polls(lrrbot, conn, event, respond_to):
 
 @bot.command("(multi)?poll (?:(\d+) )?(?:(?:https?://)?(?:www\.)?strawpoll\.me/([^/]+)(?:/r?)?|(?:([^:]+) ?: ?)?(.*))")
 @utils.mod_only
+@asyncio.coroutine
 def new_poll(lrrbot, conn, event, respond_to, multi, timeout, poll_id, title, options):
 	"""
 	Command: !poll N https://strawpoll.me/ID
@@ -55,7 +58,7 @@ def new_poll(lrrbot, conn, event, respond_to, multi, timeout, poll_id, title, op
 	"""
 	if poll_id is not None:
 		url = "https://strawpoll.me/api/v2/polls/%s" % poll_id
-		data = json.loads(utils.http_request(url))
+		data = json.loads((yield from utils.http_request_coro(url)))
 		title = data["title"]
 	else:
 		if title is None:
@@ -67,7 +70,7 @@ def new_poll(lrrbot, conn, event, respond_to, multi, timeout, poll_id, title, op
 		else:
 			options = options.split()
 		data = json.dumps({"options": options, "title": title, "multi": multi is not None})
-		response = utils.http_request("https://strawpoll.me/api/v2/polls", data, "POST", headers = {"Content-Type": "application/json"})
+		response = yield from utils.http_request_coro("https://strawpoll.me/api/v2/polls", data, "POST", headers = {"Content-Type": "application/json"})
 		poll_id = json.loads(response)["id"]
 	if timeout is not None:
 		timeout = int(timeout)
@@ -84,7 +87,7 @@ def clear_polls(lrrbot, conn, event, respond_to):
 	Command: !pollsclear
 	Section: misc
 
-	Stop tracking all active polls. The poll will still exist on strawpoll, but the bot
+	Stop tracking all active polls. The poll will still exist on Strawpoll, but the bot
 	will stop watching it for results.
 	"""
 	lrrbot.polls = []

--- a/lrrbot/googlecalendar.py
+++ b/lrrbot/googlecalendar.py
@@ -49,7 +49,7 @@ def get_upcoming_events(calendar, after=None):
 		"timeZone": config['timezone'].zone,
 		"key": config['google_key'],
 	}
-	res = yield from utils.http_request_coro(url, data)
+	res = yield from utils.http_request(url, data)
 	res = json.loads(res)
 	if 'error' in res:
 		raise Exception(res['error']['message'])

--- a/lrrbot/main.py
+++ b/lrrbot/main.py
@@ -300,7 +300,7 @@ class LRRBot(irc.bot.SingleServerIRCBot, linkspam.LinkSpam):
 		}
 		if irc.client.is_channel(event.target):
 			notifyparams['channel'] = event.target[1:]
-		yield from utils.api_request_coro('notifications/newmessage', notifyparams, 'POST')
+		yield from utils.api_request('notifications/newmessage', notifyparams, 'POST')
 
 	@asyncio.coroutine
 	def on_subscriber(self, conn, channel, user, eventtime, logo=None, monthcount=None):
@@ -338,7 +338,7 @@ class LRRBot(irc.bot.SingleServerIRCBot, linkspam.LinkSpam):
 		self.lastsubs = self.lastsubs[-10:]
 		storage.save()
 		conn.privmsg(channel, "lrrSPOT Thanks for subscribing, %s! (Today's storm count: %d)" % (notifyparams['subuser'], storage.data["storm"]["count"]))
-		yield from utils.api_request_coro('notifications/newmessage', notifyparams, 'POST')
+		yield from utils.api_request('notifications/newmessage', notifyparams, 'POST')
 
 		self.subs.add(user.lower())
 		storage.data['subs'] = list(self.subs)

--- a/lrrbot/main.py
+++ b/lrrbot/main.py
@@ -192,8 +192,8 @@ class LRRBot(irc.bot.SingleServerIRCBot, linkspam.LinkSpam):
 		log.info("Connected to server")
 		conn.cap("REQ", "twitch.tv/tags") # get metadata tags
 		conn.cap("REQ", "twitch.tv/commands") # get special commands
+		conn.cap("REQ", "twitch.tv/membership") # get join/part messages
 		conn.join("#%s" % config['channel'])
-		conn.cap("REQ", "twitch.tv/membership") # get join/part messages - after we join, so we don't get a flood of them when we arrive
 		self.check_privmsg_wrapper(conn)
 
 	def on_channel_join(self, conn, event):

--- a/lrrbot/main.py
+++ b/lrrbot/main.py
@@ -314,7 +314,7 @@ class LRRBot(irc.bot.SingleServerIRCBot, linkspam.LinkSpam):
 
 		if logo is None:
 			try:
-				channel_info = twitch.get_info(user)
+				channel_info = yield from twitch.get_info(user)
 			except:
 				pass
 			else:
@@ -379,6 +379,7 @@ class LRRBot(irc.bot.SingleServerIRCBot, linkspam.LinkSpam):
 				# Will just have to remove users from storage.data['mods'] manually
 				# should it ever come up.
 
+	@asyncio.coroutine
 	def get_current_game(self, readonly=True):
 		"""Returns the game currently being played, with caching to avoid hammering the Twitch server"""
 		show = self.show_override or self.show
@@ -386,11 +387,12 @@ class LRRBot(irc.bot.SingleServerIRCBot, linkspam.LinkSpam):
 			game_obj = {'_id': self.game_override, 'name': self.game_override, 'is_override': True}
 			return storage.find_game(show, game_obj, readonly)
 		else:
-			return storage.find_game(show, self.get_current_game_real(), readonly)
+			return storage.find_game(show, (yield from self.get_current_game_real()), readonly)
 
 	@utils.cache(GAME_CHECK_INTERVAL)
+	@asyncio.coroutine
 	def get_current_game_real(self):
-		return twitch.get_game_playing()
+		return (yield from twitch.get_game_playing())
 
 	def is_mod(self, event):
 		"""Check whether the source of the event has mod privileges for the bot, or for the channel"""

--- a/lrrbot/main.py
+++ b/lrrbot/main.py
@@ -465,7 +465,7 @@ class LRRBot(irc.bot.SingleServerIRCBot, linkspam.LinkSpam):
 	@utils.swallow_errors
 	def check_polls(self):
 		from lrrbot.commands.strawpoll import check_polls
-		check_polls(self, self.connection)
+		asyncio.async(check_polls(self, self.connection), loop=self.loop).add_done_callback(utils.check_exception)
 
 	@utils.swallow_errors
 	def vote_respond(self):

--- a/lrrbot/serverevents.py
+++ b/lrrbot/serverevents.py
@@ -2,6 +2,7 @@ import random
 import re
 import math
 import logging
+import asyncio
 
 from common import utils
 from lrrbot import googlecalendar, storage, commands
@@ -11,6 +12,7 @@ from lrrbot.main import bot
 log = logging.getLogger('serverevents')
 
 @bot.server_event()
+@asyncio.coroutine
 def current_game(lrrbot, user, data):
 	game = lrrbot.get_current_game()
 	if game:
@@ -19,6 +21,7 @@ def current_game(lrrbot, user, data):
 		return None
 
 @bot.server_event()
+@asyncio.coroutine
 def current_game_name(lrrbot, user, data):
 	game = lrrbot.get_current_game()
 	if game:
@@ -27,6 +30,7 @@ def current_game_name(lrrbot, user, data):
 		return None
 
 @bot.server_event()
+@asyncio.coroutine
 def get_data(lrrbot, user, data):
 	if not isinstance(data['key'], (list, tuple)):
 		data['key'] = [data['key']]
@@ -36,6 +40,7 @@ def get_data(lrrbot, user, data):
 	return node
 
 @bot.server_event()
+@asyncio.coroutine
 def set_data(lrrbot, user, data):
 	if not isinstance(data['key'], (list, tuple)):
 		data['key'] = [data['key']]
@@ -52,22 +57,26 @@ def set_data(lrrbot, user, data):
 	storage.save()
 
 @bot.server_event()
+@asyncio.coroutine
 def modify_commands(lrrbot, user, data):
 	commands.static.modify_commands(data)
 	bot.compile()
 
 @bot.server_event()
+@asyncio.coroutine
 def modify_explanations(lrrbot, user, data):
 	commands.explain.modify_explanations(data)
 	bot.compile()
 
 @bot.server_event()
+@asyncio.coroutine
 def modify_spam_rules(lrrbot, user, data):
 	storage.data['spam_rules'] = data
 	storage.save()
 	lrrbot.spam_rules = [(re.compile(i['re']), i['message']) for i in storage.data['spam_rules']]
 
 @bot.server_event()
+@asyncio.coroutine
 def get_commands(lrrbot, user, data):
 	ret = []
 	for command in lrrbot.commands.values():
@@ -90,6 +99,7 @@ def get_commands(lrrbot, user, data):
 	return ret
 
 @bot.server_event()
+@asyncio.coroutine
 def get_header_info(lrrbot, user, data):
 	game = lrrbot.get_current_game()
 	data = {}
@@ -131,10 +141,12 @@ def get_header_info(lrrbot, user, data):
 	return data
 
 @bot.server_event()
+@asyncio.coroutine
 def nextstream(lrrbot, user, data):
 	return googlecalendar.get_next_event_text(googlecalendar.CALENDAR_LRL, verbose=False)
 
 @bot.server_event()
+@asyncio.coroutine
 def set_show(lrrbot, user, data):
 	if user is not None and lrrbot.is_mod_nick(user):
 		commands.show.set_show(lrrbot, data["show"])
@@ -142,10 +154,12 @@ def set_show(lrrbot, user, data):
 	return {"status": "error: %s is not a mod" % user}
 
 @bot.server_event()
+@asyncio.coroutine
 def get_show(lrrbot, user, data):
 	return lrrbot.show_override or lrrbot.show
 
 @bot.server_event()
+@asyncio.coroutine
 @utils.with_postgres
 def get_tweet(conn, cur, lrrbot, user, data):
 	if user is not None and lrrbot.is_mod_nick(user):

--- a/lrrbot/serverevents.py
+++ b/lrrbot/serverevents.py
@@ -14,7 +14,7 @@ log = logging.getLogger('serverevents')
 @bot.server_event()
 @asyncio.coroutine
 def current_game(lrrbot, user, data):
-	game = lrrbot.get_current_game()
+	game = yield from lrrbot.get_current_game()
 	if game:
 		return game['id']
 	else:
@@ -23,7 +23,7 @@ def current_game(lrrbot, user, data):
 @bot.server_event()
 @asyncio.coroutine
 def current_game_name(lrrbot, user, data):
-	game = lrrbot.get_current_game()
+	game = yield from lrrbot.get_current_game()
 	if game:
 		return game['name']
 	else:
@@ -101,7 +101,7 @@ def get_commands(lrrbot, user, data):
 @bot.server_event()
 @asyncio.coroutine
 def get_header_info(lrrbot, user, data):
-	game = lrrbot.get_current_game()
+	game = yield from lrrbot.get_current_game()
 	data = {}
 	if game is not None:
 		data['current_game'] = {

--- a/lrrbot/serverevents.py
+++ b/lrrbot/serverevents.py
@@ -143,7 +143,7 @@ def get_header_info(lrrbot, user, data):
 @bot.server_event()
 @asyncio.coroutine
 def nextstream(lrrbot, user, data):
-	return googlecalendar.get_next_event_text(googlecalendar.CALENDAR_LRL, verbose=False)
+	return (yield from googlecalendar.get_next_event_text(googlecalendar.CALENDAR_LRL, verbose=False))
 
 @bot.server_event()
 @asyncio.coroutine

--- a/lrrbot/twitch.py
+++ b/lrrbot/twitch.py
@@ -99,11 +99,12 @@ def get_subscribers(channel=None, count=5, offset=None, latest=True):
 		for sub in subscriber_data['subscriptions']
 	]
 
+@asyncio.coroutine
 def get_group_servers():
 	"""
 	Get the secondary Twitch chat servers
 	"""
-	res = utils.http_request("https://chatdepot.twitch.tv/room_memberships", {'oauth_token': storage.data['twitch_oauth'][config['username']]}, maxtries=1)
+	res = yield from utils.http_request_coro("https://chatdepot.twitch.tv/room_memberships", {'oauth_token': storage.data['twitch_oauth'][config['username']]}, maxtries=1)
 	res = json.loads(res)
 	def parse_server(s):
 		if ':' in s:

--- a/lrrbot/twitch.py
+++ b/lrrbot/twitch.py
@@ -23,7 +23,7 @@ def get_info(username=None, use_fallback=True):
 
 	# Attempt to get the channel data from /streams/channelname
 	# If this succeeds, it means the channel is currently live
-	res = yield from utils.http_request_coro("https://api.twitch.tv/kraken/streams/%s" % username)
+	res = yield from utils.http_request("https://api.twitch.tv/kraken/streams/%s" % username)
 	data = json.loads(res)
 	channel_data = data.get('stream') and data['stream'].get('channel')
 	if channel_data:
@@ -57,7 +57,7 @@ def get_game(name, all=False):
 		'type': 'suggest',
 		'live': 'false',
 	}
-	res = yield from utils.http_request_coro("https://api.twitch.tv/kraken/search/games", search_opts)
+	res = yield from utils.http_request("https://api.twitch.tv/kraken/search/games", search_opts)
 	res = json.loads(res)
 	if all:
 		return res['games']
@@ -94,7 +94,7 @@ def get_subscribers(channel=None, count=5, offset=None, latest=True):
 	}
 	if offset is not None:
 		data['offset'] = offset
-	res = yield from utils.http_request_coro("https://api.twitch.tv/kraken/channels/%s/subscriptions" % channel, headers=headers, data=data)
+	res = yield from utils.http_request("https://api.twitch.tv/kraken/channels/%s/subscriptions" % channel, headers=headers, data=data)
 	subscriber_data = json.loads(res)
 	return [
 		(sub['user']['display_name'], sub['user'].get('logo'), sub['created_at'])
@@ -106,7 +106,7 @@ def get_group_servers():
 	"""
 	Get the secondary Twitch chat servers
 	"""
-	res = yield from utils.http_request_coro("https://chatdepot.twitch.tv/room_memberships", {'oauth_token': storage.data['twitch_oauth'][config['username']]}, maxtries=1)
+	res = yield from utils.http_request("https://chatdepot.twitch.tv/room_memberships", {'oauth_token': storage.data['twitch_oauth'][config['username']]}, maxtries=1)
 	res = json.loads(res)
 	def parse_server(s):
 		if ':' in s:
@@ -138,7 +138,7 @@ def get_follows_channels(username=None):
 	follows = []
 	total = 1
 	while len(follows) < total:
-		data = yield from utils.http_request_coro(url)
+		data = yield from utils.http_request(url)
 		data = json.loads(data)
 		total = data["_total"]
 		follows += data["follows"]
@@ -156,7 +156,7 @@ def get_streams_followed(username=None):
 	streams = []
 	total = 1
 	while len(streams) < total:
-		data = yield from utils.http_request_coro(url, headers=headers)
+		data = yield from utils.http_request(url, headers=headers)
 		data = json.loads(data)
 		total = data["_total"]
 		streams += data["streams"]
@@ -170,7 +170,7 @@ def follow_channel(target, user=None):
 	headers = {
 		"Authorization": "OAuth %s" % storage.data['twitch_oauth'][user],
 	}
-	yield from utils.http_request_coro("https://api.twitch.tv/kraken/users/%s/follows/channels/%s" % (user, target),
+	yield from utils.http_request("https://api.twitch.tv/kraken/users/%s/follows/channels/%s" % (user, target),
 									data={"notifications": "false"}, method="PUT", headers=headers)
 
 @asyncio.coroutine
@@ -180,13 +180,13 @@ def unfollow_channel(target, user=None):
 	headers = {
 		"Authorization": "OAuth %s" % storage.data['twitch_oauth'][user],
 	}
-	yield from utils.http_request_coro("https://api.twitch.tv/kraken/users/%s/follows/channels/%s" % (user, target),
+	yield from utils.http_request("https://api.twitch.tv/kraken/users/%s/follows/channels/%s" % (user, target),
 									method="DELETE", headers=headers)
 
 @asyncio.coroutine
 def get_videos(channel=None, offset=0, limit=10, broadcasts=False, hls=False):
 	channel = channel or config["channel"]
-	data = yield from utils.http_request_coro("https://api.twitch.tv/kraken/channels/%s/videos" % channel, data={
+	data = yield from utils.http_request("https://api.twitch.tv/kraken/channels/%s/videos" % channel, data={
 		"offset": offset,
 		"limit": limit,
 		"broadcasts": "true" if broadcasts else "false",

--- a/lrrbot/twitchsubs.py
+++ b/lrrbot/twitchsubs.py
@@ -37,7 +37,7 @@ def do_check(lrrbot):
 			if user.lower() not in last_subs:
 				log.info("Found new subscriber via Twitch API: %s" % user)
 				eventtime = dateutil.parser.parse(eventtime).timestamp()
-				lrrbot.on_api_subscriber(user, logo, eventtime, config['channel'])
+				yield from lrrbot.on_api_subscriber(user, logo, eventtime, config['channel'])
 	else:
 		log.debug("Got initial subscriber list from Twitch")
 

--- a/lrrbot/whisper.py
+++ b/lrrbot/whisper.py
@@ -14,7 +14,7 @@ class TwitchWhisper(irc.bot.SingleServerIRCBot):
 			host=host,
 			port=port,
 			password="oauth:%s" % storage.data['twitch_oauth'][config['username']] if config['password'] == "oauth" else config['password'],
-		) for host, port in twitch.get_group_servers()]
+		) for host, port in loop.run_until_complete(twitch.get_group_servers())]
 		super(TwitchWhisper, self).__init__(
 			server_list=servers,
 			realname=config['username'],

--- a/www/login.py
+++ b/www/login.py
@@ -1,3 +1,4 @@
+import asyncio
 import functools
 import urllib.request
 import urllib.parse
@@ -23,6 +24,7 @@ SPECIAL_USERS = {
 REDIRECT_URI = 'https://lrrbot.mrphlip.com/login'
 #REDIRECT_URI = 'http://localhost:5000/login'
 
+@utils.coro_decorator
 def with_session(func):
 	"""
 	Pass the current login session information to the function
@@ -34,11 +36,13 @@ def with_session(func):
 		...
 	"""
 	@functools.wraps(func)
+	@asyncio.coroutine
 	def wrapper(*args, **kwargs):
 		kwargs['session'] = load_session()
-		return func(*args, **kwargs)
+		return (yield from func(*args, **kwargs))
 	return wrapper
 
+@utils.coro_decorator
 def with_minimal_session(func):
 	"""
 	Pass the current login session information to the function
@@ -54,26 +58,30 @@ def with_minimal_session(func):
 		...
 	"""
 	@functools.wraps(func)
+	@asyncio.coroutine
 	def wrapper(*args, **kwargs):
 		kwargs['session'] = load_session(include_url=False, include_header=False)
-		return func(*args, **kwargs)
+		return (yield from func(*args, **kwargs))
 	return wrapper
 
+@utils.coro_decorator
 def require_login(func):
 	"""
 	Like with_session, but if the user isn't logged in,
 	send them via the login screen.
 	"""
 	@functools.wraps(func)
+	@asyncio.coroutine
 	def wrapper(*args, **kwargs):
 		session = load_session()
 		if session['user']:
 			kwargs['session'] = session
-			return func(*args, **kwargs)
+			return (yield from func(*args, **kwargs))
 		else:
 			return login(session['url'])
 	return wrapper
 
+@utils.coro_decorator
 def require_mod(func):
 	"""
 	Like with_session, but if the user isn't logged in,
@@ -81,12 +89,13 @@ def require_mod(func):
 	a moderator, kick them out.
 	"""
 	@functools.wraps(func)
+	@asyncio.coroutine
 	def wrapper(*args, **kwargs):
 		session = load_session()
 		if session['user']:
 			kwargs['session'] = session
 			if session['header']['is_mod']:
-				return func(*args, **kwargs)
+				return (yield from func(*args, **kwargs))
 			else:
 				return flask.render_template('require_mod.html', session=session)
 		else:

--- a/www/server.py
+++ b/www/server.py
@@ -1,5 +1,28 @@
 from flask import Flask
 from flaskext.csrf import csrf
-app = Flask(__name__)
+
+import asyncio
+import functools
+
+class Application(Flask):
+	def __init__(self, *args, **kwargs):
+		self.__wrapped_view_funcs = {}
+		super().__init__(*args, **kwargs)
+
+	def add_url_rule(self, rule, endpoint, view_func, **options):
+		# Cache the wrapper functions so Flask doesn't complain.
+		if asyncio.iscoroutinefunction(view_func) and view_func not in self.__wrapped_view_funcs:
+			@functools.wraps(view_func)
+			def inner(*args, **kwargs):
+				return asyncio.get_event_loop().run_until_complete(view_func(*args, **kwargs))
+			self.__wrapped_view_funcs[view_func] = inner
+			func = inner
+		else:
+			func = view_func
+
+		return super().add_url_rule(rule, endpoint, func, **options)
+
+app = Application(__name__)
 csrf(app)
+
 __all__ = ['app']

--- a/www/spam.py
+++ b/www/spam.py
@@ -58,16 +58,16 @@ def do_check(line, rules):
 			return rule['message'] % groups
 	return None
 
+@asyncio.coroutine
 def do_check_links(message, rules):
-	loop = asyncio.get_event_loop()
-	re_url = loop.run_until_complete(utils.url_regex())
+	re_url = yield from utils.url_regex()
 	urls = []
 	for match in re_url.finditer(message):
 		for url in match.groups():
 			if url is not None:
 				urls.append(url)
 				break
-	canonical_urls = loop.run_until_complete(asyncio.gather(*map(utils.canonical_url, urls), loop=loop))
+	canonical_urls = yield from asyncio.gather(*map(utils.canonical_url, urls))
 	for url_chain in canonical_urls:
 		for url in url_chain:
 			for rule in rules:
@@ -77,13 +77,14 @@ def do_check_links(message, rules):
 
 @server.app.route('/spam/redirects')
 @login.require_mod
+@asyncio.coroutine
 def spam_redirects(session):
-	loop = asyncio.get_event_loop()
-	redirects = loop.run_until_complete(utils.canonical_url(flask.request.values["url"].strip()))
+	redirects = yield from utils.canonical_url(flask.request.values["url"].strip())
 	return flask.json.jsonify(redirects=redirects, csrf_token=server.app.csrf_token())
 
 @server.app.route('/spam/test', methods=['POST'])
 @login.require_mod
+@asyncio.coroutine
 def spam_test(session):
 	link_spam = "link_spam" in flask.request.values
 	rules = flask.json.loads(flask.request.values['data'])
@@ -99,13 +100,13 @@ def spam_test(session):
 
 	result = []
 
-	check = do_check_links if link_spam else do_check
+	check = do_check_links if link_spam else asyncio.coroutine(do_check)
 
 	re_twitchchat = re.compile("^\w*:\s*(.*)$")
 	re_irc = re.compile("<[^<>]*>\s*(.*)$")
 	lines = message.split('\n')
 	for line in lines:
-		res = check(line, rules)
+		res = yield from check(line, rules)
 		if res is None:
 			match = re_twitchchat.search(line)
 			if match:


### PR DESCRIPTION
* Replaces all uses of `utils.{api,http}_request` with `utils.{api,http}_request_coro`. The website and the card database builder continue to use `urllib` directly.
* Moves membership capability before `JOIN`. User list is now accurate*. `!viewers` throttle timeout lowered. No `JOIN` storm at startup because `NAMES` don't get converted into `JOIN`s.
* Rewrites the RPC server to use [streams](https://docs.python.org/3/library/asyncio-stream.html). All RPC handler functions are now coroutines.
* Removes `utils.{api,http}_request`.
* Renames `utils.{api,http}_request_coro` to `utils.{api,http}_request`.

\* Twitch, pls.