### PR TITLE
Move code from `common.utils`

### DIFF
--- a/build_carddb.py
+++ b/build_carddb.py
@@ -20,7 +20,6 @@ import dateutil.parser
 
 from lrrbot.commands.card import clean_text
 
-
 URL = 'http://mtgjson.com/json/AllSets.json.zip'
 ZIP_FILENAME = 'AllSets.json.zip'
 SOURCE_FILENAME = 'AllSets.json'

--- a/common/config.py
+++ b/common/config.py
@@ -5,7 +5,6 @@ import pytz
 
 from common.commandline import argv
 
-
 CONFIG_SECTION = 'lrrbot'
 
 config = configparser.ConfigParser()

--- a/common/gdata.py
+++ b/common/gdata.py
@@ -1,5 +1,6 @@
 import time
 
+import common.http
 from common import utils
 
 import asyncio
@@ -43,7 +44,7 @@ def get_oauth_token(scopes):
 
 	data = {"grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer", "assertion": jwt}
 
-	ret = json.loads((yield from utils.http_request_coro("https://accounts.google.com/o/oauth2/token", data, "POST")))
+	ret = json.loads((yield from common.http.http_request_coro("https://accounts.google.com/o/oauth2/token", data, "POST")))
 	if "error" in ret:
 		raise Exception(ret["error"])
 	return ret
@@ -64,12 +65,12 @@ def add_rows_to_spreadsheet(spreadsheet, rows):
 	token = yield from get_oauth_token(["https://spreadsheets.google.com/feeds"])
 	headers = {"Authorization": "%(token_type)s %(access_token)s" % token}
 	url = "https://spreadsheets.google.com/feeds/worksheets/%s/private/full" % spreadsheet
-	tree = xml.dom.minidom.parseString((yield from utils.http_request_coro(url, headers=headers)))
+	tree = xml.dom.minidom.parseString((yield from common.http.http_request_coro(url, headers=headers)))
 	worksheet = next(iter(tree.getElementsByTagName("entry")))
 	list_feed = find_schema(worksheet, "http://schemas.google.com/spreadsheets/2006#listfeed")
 	if list_feed is None:
 		raise Exception("List feed missing.")
-	list_feed = xml.dom.minidom.parseString((yield from utils.http_request_coro(list_feed, headers=headers)))
+	list_feed = xml.dom.minidom.parseString((yield from common.http.http_request_coro(list_feed, headers=headers)))
 	post_url = find_schema(list_feed, "http://schemas.google.com/g/2005#post")
 	if post_url is None:
 		raise Exception("POST URL missing.")
@@ -83,4 +84,4 @@ def add_rows_to_spreadsheet(spreadsheet, rows):
 			root.appendChild(new_field(doc, column, value))
 
 		headers["Content-Type"] = "application/atom+xml"
-		yield from utils.http_request_coro(post_url, headers=headers, data=doc.toxml(), method="POST")
+		yield from common.http.http_request_coro(post_url, headers=headers, data=doc.toxml(), method="POST")

--- a/common/gdata.py
+++ b/common/gdata.py
@@ -44,7 +44,7 @@ def get_oauth_token(scopes):
 
 	data = {"grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer", "assertion": jwt}
 
-	ret = json.loads((yield from common.http.http_request_coro("https://accounts.google.com/o/oauth2/token", data, "POST")))
+	ret = json.loads((yield from common.http.request_coro("https://accounts.google.com/o/oauth2/token", data, "POST")))
 	if "error" in ret:
 		raise Exception(ret["error"])
 	return ret
@@ -65,12 +65,12 @@ def add_rows_to_spreadsheet(spreadsheet, rows):
 	token = yield from get_oauth_token(["https://spreadsheets.google.com/feeds"])
 	headers = {"Authorization": "%(token_type)s %(access_token)s" % token}
 	url = "https://spreadsheets.google.com/feeds/worksheets/%s/private/full" % spreadsheet
-	tree = xml.dom.minidom.parseString((yield from common.http.http_request_coro(url, headers=headers)))
+	tree = xml.dom.minidom.parseString((yield from common.http.request_coro(url, headers=headers)))
 	worksheet = next(iter(tree.getElementsByTagName("entry")))
 	list_feed = find_schema(worksheet, "http://schemas.google.com/spreadsheets/2006#listfeed")
 	if list_feed is None:
 		raise Exception("List feed missing.")
-	list_feed = xml.dom.minidom.parseString((yield from common.http.http_request_coro(list_feed, headers=headers)))
+	list_feed = xml.dom.minidom.parseString((yield from common.http.request_coro(list_feed, headers=headers)))
 	post_url = find_schema(list_feed, "http://schemas.google.com/g/2005#post")
 	if post_url is None:
 		raise Exception("POST URL missing.")
@@ -84,4 +84,4 @@ def add_rows_to_spreadsheet(spreadsheet, rows):
 			root.appendChild(new_field(doc, column, value))
 
 		headers["Content-Type"] = "application/atom+xml"
-		yield from common.http.http_request_coro(post_url, headers=headers, data=doc.toxml(), method="POST")
+		yield from common.http.request_coro(post_url, headers=headers, data=doc.toxml(), method="POST")

--- a/common/gdata.py
+++ b/common/gdata.py
@@ -1,7 +1,6 @@
 import time
 
 import common.http
-from common import utils
 
 import asyncio
 
@@ -13,7 +12,6 @@ import json
 import base64
 import xml.dom
 import xml.dom.minidom
-
 
 def base64_encode(data):
 	return base64.urlsafe_b64encode(data).strip(b"=")

--- a/common/highlights.py
+++ b/common/highlights.py
@@ -1,3 +1,4 @@
+import common.time
 from common import utils
 
 SPREADSHEET = "1yrf6d7dPyTiWksFkhISqEc-JR71dxZMkUoYrX4BR40Y"
@@ -7,6 +8,6 @@ def format_row(title, description, url, timestamp, nick):
 		("SHOW", title),
 		("QUOTE or MOMENT", description),
 		("YOUTUBE VIDEO LINK", url),
-		("ROUGH TIME THEREIN", "before " + utils.nice_duration(timestamp, 0)),
+		("ROUGH TIME THEREIN", "before " + common.time.nice_duration(timestamp, 0)),
 		("NOTES", "from chat user '%s'" % nick),
 	]

--- a/common/highlights.py
+++ b/common/highlights.py
@@ -1,5 +1,4 @@
 import common.time
-from common import utils
 
 SPREADSHEET = "1yrf6d7dPyTiWksFkhISqEc-JR71dxZMkUoYrX4BR40Y"
 

--- a/common/http.py
+++ b/common/http.py
@@ -1,0 +1,133 @@
+import asyncio
+import atexit
+import json
+import logging
+import urllib.parse
+import urllib.request
+
+import aiohttp
+
+from common import config
+log = logging.getLogger("common.http")
+
+class Request(urllib.request.Request):
+	"""Override the get_method method of Request, adding the "method" field that doesn't exist until Python 3.3"""
+	def __init__(self, *args, method=None, **kwargs):
+		super().__init__(*args, **kwargs)
+		self.method = method
+	def get_method(self):
+		if self.method is not None:
+			return self.method
+		else:
+			return super().get_method()
+
+
+def http_request(url, data=None, method='GET', maxtries=3, headers={}, timeout=5, **kwargs):
+	"""Download a webpage, with retries on failure."""
+	# Let's be nice.
+	headers["User-Agent"] = "LRRbot/2.0 (https://lrrbot.mrphlip.com/)"
+	if data:
+		if isinstance(data, dict):
+			data = urllib.parse.urlencode(data)
+		if method == 'GET':
+			url = '%s?%s' % (url, data)
+			req = Request(url=url, method='GET', headers=headers, **kwargs)
+		elif method == 'POST':
+			req = Request(url=url, data=data.encode("utf-8"), method='POST', headers=headers, **kwargs)
+		elif method == 'PUT':
+			req = Request(url=url, data=data.encode("utf-8"), method='PUT', headers=headers, **kwargs)
+	else:
+		req = Request(url=url, method='GET', headers=headers, **kwargs)
+
+	firstex = None
+	while True:
+		try:
+			return urllib.request.urlopen(req, timeout=timeout).read().decode("utf-8")
+		except Exception as e:
+			maxtries -= 1
+			if firstex is None:
+				firstex = e
+			if maxtries > 0:
+				log.info("Downloading %s failed: %s: %s, retrying...", url, e.__class__.__name__, e)
+			else:
+				break
+	raise firstex
+
+
+# Limit the number of parallel HTTP connections to a server.
+http_request_session = aiohttp.ClientSession(connector=aiohttp.TCPConnector(limit=6))
+atexit.register(http_request_session.close)
+@asyncio.coroutine
+def http_request_coro(url, data=None, method='GET', maxtries=3, headers={}, timeout=5, allow_redirects=True):
+	headers["User-Agent"] = "LRRbot/2.0 (https://lrrbot.mrphlip.com/)"
+	firstex = None
+
+	# FIXME(#130): aiohttp fails to decode HEAD requests with Content-Encoding set. Do GET requests instead.
+	real_method = method
+	if method == 'HEAD':
+		real_method = 'GET'
+
+	if method == 'GET':
+		params = data
+		data = None
+	else:
+		params = None
+	while True:
+		try:
+			res = yield from asyncio.wait_for(http_request_session.request(real_method, url, params=params, data=data, headers=headers, allow_redirects=allow_redirects), timeout)
+			if method == "HEAD":
+				yield from res.release()
+				return res
+			status_class = res.status // 100
+			if status_class != 2:
+				yield from res.read()
+				if status_class == 4:
+					maxtries = 1
+				yield from res.release()
+				raise urllib.error.HTTPError(res.url, res.status, res.reason, res.headers, None)
+			text = yield from res.text()
+			yield from res.release()
+			return text
+		except Exception as e:
+			maxtries -= 1
+			if firstex is None:
+				firstex = e
+			if maxtries > 0:
+				log.info("Downloading %s failed: %s: %s, retrying...", url, e.__class__.__name__, e)
+			else:
+				break
+	raise firstex
+
+
+def api_request(uri, *args, **kwargs):
+	# Send the information to the server
+	try:
+		res = http_request(config.config['siteurl'] + uri, *args, **kwargs)
+	except:
+		log.exception("Error at server in %s" % uri)
+	else:
+		try:
+			res = json.loads(res)
+		except:
+			log.exception("Error parsing server response from %s: %s", uri, res)
+		else:
+			if 'success' not in res:
+				log.error("Error at server in %s" % uri)
+			return res
+
+
+@asyncio.coroutine
+def api_request_coro(uri, *args, **kwargs):
+	try:
+		res = yield from http_request_coro(config.config['siteurl'] + uri, *args, **kwargs)
+	except:
+		log.exception("Error at server in %s" % uri)
+	else:
+		try:
+			res = json.loads(res)
+		except:
+			log.exception("Error parsing server response from %s: %s", uri, res)
+		else:
+			if 'success' not in res:
+				log.error("Error at server in %s" % uri)
+			return res

--- a/common/http.py
+++ b/common/http.py
@@ -8,6 +8,7 @@ import urllib.request
 import aiohttp
 
 from common import config
+
 log = logging.getLogger("common.http")
 
 class Request(urllib.request.Request):
@@ -20,7 +21,6 @@ class Request(urllib.request.Request):
 			return self.method
 		else:
 			return super().get_method()
-
 
 def request(url, data=None, method='GET', maxtries=3, headers={}, timeout=5, **kwargs):
 	"""Download a webpage, with retries on failure."""
@@ -52,7 +52,6 @@ def request(url, data=None, method='GET', maxtries=3, headers={}, timeout=5, **k
 			else:
 				break
 	raise firstex
-
 
 # Limit the number of parallel HTTP connections to a server.
 http_request_session = aiohttp.ClientSession(connector=aiohttp.TCPConnector(limit=6))
@@ -98,7 +97,6 @@ def request_coro(url, data=None, method='GET', maxtries=3, headers={}, timeout=5
 				break
 	raise firstex
 
-
 def api_request(uri, *args, **kwargs):
 	# Send the information to the server
 	try:
@@ -114,7 +112,6 @@ def api_request(uri, *args, **kwargs):
 			if 'success' not in res:
 				log.error("Error at server in %s" % uri)
 			return res
-
 
 @asyncio.coroutine
 def api_request_coro(uri, *args, **kwargs):

--- a/common/http.py
+++ b/common/http.py
@@ -22,7 +22,7 @@ class Request(urllib.request.Request):
 			return super().get_method()
 
 
-def http_request(url, data=None, method='GET', maxtries=3, headers={}, timeout=5, **kwargs):
+def request(url, data=None, method='GET', maxtries=3, headers={}, timeout=5, **kwargs):
 	"""Download a webpage, with retries on failure."""
 	# Let's be nice.
 	headers["User-Agent"] = "LRRbot/2.0 (https://lrrbot.mrphlip.com/)"
@@ -58,7 +58,7 @@ def http_request(url, data=None, method='GET', maxtries=3, headers={}, timeout=5
 http_request_session = aiohttp.ClientSession(connector=aiohttp.TCPConnector(limit=6))
 atexit.register(http_request_session.close)
 @asyncio.coroutine
-def http_request_coro(url, data=None, method='GET', maxtries=3, headers={}, timeout=5, allow_redirects=True):
+def request_coro(url, data=None, method='GET', maxtries=3, headers={}, timeout=5, allow_redirects=True):
 	headers["User-Agent"] = "LRRbot/2.0 (https://lrrbot.mrphlip.com/)"
 	firstex = None
 
@@ -102,7 +102,7 @@ def http_request_coro(url, data=None, method='GET', maxtries=3, headers={}, time
 def api_request(uri, *args, **kwargs):
 	# Send the information to the server
 	try:
-		res = http_request(config.config['siteurl'] + uri, *args, **kwargs)
+		res = request(config.config['siteurl'] + uri, *args, **kwargs)
 	except:
 		log.exception("Error at server in %s" % uri)
 	else:
@@ -119,7 +119,7 @@ def api_request(uri, *args, **kwargs):
 @asyncio.coroutine
 def api_request_coro(uri, *args, **kwargs):
 	try:
-		res = yield from http_request_coro(config.config['siteurl'] + uri, *args, **kwargs)
+		res = yield from request_coro(config.config['siteurl'] + uri, *args, **kwargs)
 	except:
 		log.exception("Error at server in %s" % uri)
 	else:

--- a/common/postgres.py
+++ b/common/postgres.py
@@ -1,0 +1,35 @@
+import functools
+import random
+
+import psycopg2
+
+from common import config
+
+
+def get_postgres():
+	return psycopg2.connect(config.config["postgres"])
+
+
+def with_postgres(func):
+	"""Decorator to pass a PostgreSQL connection and cursor to a function"""
+	@functools.wraps(func)
+	def wrapper(*args, **kwargs):
+		with get_postgres() as conn, conn.cursor() as cur:
+			return func(conn, cur, *args, **kwargs)
+	return wrapper
+
+
+def pick_random_row(cur, query, params = ()):
+	" Return a random row of a SELECT query. "
+	# CSE - common subexpression elimination, an optimisation Postgres doesn't do
+	cur.execute("CREATE TEMP TABLE cse AS " + query, params)
+	if cur.rowcount <= 0:
+		return None
+	cur.execute("SELECT * FROM cse OFFSET %s LIMIT 1", (random.randrange(cur.rowcount), ))
+	row = cur.fetchone()
+	cur.execute("DROP TABLE cse")
+	return row
+
+
+def escape_like(s):
+	return s.replace('\\', '\\\\').replace('%', '\\%').replace('_', '\\_')

--- a/common/postgres.py
+++ b/common/postgres.py
@@ -1,5 +1,4 @@
 import functools
-import random
 
 import psycopg2
 
@@ -15,17 +14,6 @@ def with_postgres(func):
 		with get_postgres() as conn, conn.cursor() as cur:
 			return func(conn, cur, *args, **kwargs)
 	return wrapper
-
-def pick_random_row(cur, query, params = ()):
-	" Return a random row of a SELECT query. "
-	# CSE - common subexpression elimination, an optimisation Postgres doesn't do
-	cur.execute("CREATE TEMP TABLE cse AS " + query, params)
-	if cur.rowcount <= 0:
-		return None
-	cur.execute("SELECT * FROM cse OFFSET %s LIMIT 1", (random.randrange(cur.rowcount), ))
-	row = cur.fetchone()
-	cur.execute("DROP TABLE cse")
-	return row
 
 def escape_like(s):
 	return s.replace('\\', '\\\\').replace('%', '\\%').replace('_', '\\_')

--- a/common/postgres.py
+++ b/common/postgres.py
@@ -5,10 +5,8 @@ import psycopg2
 
 from common import config
 
-
 def get_postgres():
 	return psycopg2.connect(config.config["postgres"])
-
 
 def with_postgres(func):
 	"""Decorator to pass a PostgreSQL connection and cursor to a function"""
@@ -17,7 +15,6 @@ def with_postgres(func):
 		with get_postgres() as conn, conn.cursor() as cur:
 			return func(conn, cur, *args, **kwargs)
 	return wrapper
-
 
 def pick_random_row(cur, query, params = ()):
 	" Return a random row of a SELECT query. "
@@ -29,7 +26,6 @@ def pick_random_row(cur, query, params = ()):
 	row = cur.fetchone()
 	cur.execute("DROP TABLE cse")
 	return row
-
 
 def escape_like(s):
 	return s.replace('\\', '\\\\').replace('%', '\\%').replace('_', '\\_')

--- a/common/time.py
+++ b/common/time.py
@@ -6,7 +6,6 @@ import pytz
 
 from common import config
 
-
 def nice_duration(s, detail=1):
 	"""
 	Convert a duration in seconds to a human-readable duration.
@@ -31,7 +30,6 @@ def nice_duration(s, detail=1):
 	d, h = divmod(h, 24)
 	return ["%(d)dd, %(h)d:%(m)02d:%(s)02d", "%(d)dd, %(h)d:%(m)02d", "%(d)dd, %(h)dh"][detail] % {'s': s, 'm': m, 'h': h, 'd': d}
 
-
 def get_timezone(tz):
 	"""
 	Look up a timezone by name, case-insensitively
@@ -46,11 +44,8 @@ def get_timezone(tz):
 		else:
 			raise
 
-
 re_timefmt1 = re.compile("^\s*(?:\s*(\d*)\s*d)?(?:\s*(\d*)\s*h)?(?:\s*(\d*)\s*m)?(?:\s*(\d*)\s*s?)?\s*$")
 re_timefmt2 = re.compile("^(?:(?:(?:\s*(\d*)\s*:)?\s*(\d*)\s*:)?\s*(\d*)\s*:)?\s*(\d*)\s*$")
-
-
 def parsetime(s):
 	"""
 	Parse user-supplied times in one of two formats:
@@ -79,12 +74,10 @@ def parsetime(s):
 	s = int(match.group(4) or 0)
 	return datetime.timedelta(days=d, hours=h, minutes=m, seconds=s)
 
-
 def strtotime(s):
 	if isinstance(s, str):
 		s = s.encode("utf-8")
 	return datetime.datetime.fromtimestamp(timelib.strtotime(s), tz=pytz.utc)
-
 
 def strtodate(s):
 	dt = strtotime(s)

--- a/common/time.py
+++ b/common/time.py
@@ -1,0 +1,96 @@
+import datetime
+import re
+import timelib
+
+import pytz
+
+from common import config
+
+
+def nice_duration(s, detail=1):
+	"""
+	Convert a duration in seconds to a human-readable duration.
+
+	detail can be:
+		0 - Always show to the nearest second
+		1 - Show to the nearest minute, unless less than a minute
+		2 - Show to the nearest hour, unless less than an hour
+	"""
+	if isinstance(s, datetime.timedelta):
+		s = s.days * 86400 + s.seconds
+	if s < 0:
+		return "-" + nice_duration(-s, detail)
+	if s < 60:
+		return ["0:%(s)02d", "%(s)ds", "%(s)ds"][detail] % {'s': s}
+	m, s = divmod(s, 60)
+	if m < 60:
+		return ["%(m)d:%(s)02d", "%(m)dm", "%(m)dm"][detail] % {'s': s, 'm': m}
+	h, m = divmod(m, 60)
+	if h < 24:
+		return ["%(h)d:%(m)02d:%(s)02d", "%(h)d:%(m)02d", "%(h)dh"][detail] % {'s': s, 'm': m, 'h': h}
+	d, h = divmod(h, 24)
+	return ["%(d)dd, %(h)d:%(m)02d:%(s)02d", "%(d)dd, %(h)d:%(m)02d", "%(d)dd, %(h)dh"][detail] % {'s': s, 'm': m, 'h': h, 'd': d}
+
+
+def get_timezone(tz):
+	"""
+	Look up a timezone by name, case-insensitively
+	"""
+	try:
+		return pytz.timezone(tz)
+	except pytz.exceptions.UnknownTimeZoneError:
+		tznames = {i.lower(): i for i in pytz.all_timezones}
+		tz = tz.lower()
+		if tz in tznames:
+			return pytz.timezone(tznames[tz])
+		else:
+			raise
+
+
+re_timefmt1 = re.compile("^\s*(?:\s*(\d*)\s*d)?(?:\s*(\d*)\s*h)?(?:\s*(\d*)\s*m)?(?:\s*(\d*)\s*s?)?\s*$")
+re_timefmt2 = re.compile("^(?:(?:(?:\s*(\d*)\s*:)?\s*(\d*)\s*:)?\s*(\d*)\s*:)?\s*(\d*)\s*$")
+
+
+def parsetime(s):
+	"""
+	Parse user-supplied times in one of two formats:
+	"10s"
+	"5m3s"
+	"7h2m"
+	"1d7m52s"
+	or:
+	"10"
+	"5:03"
+	"7:02:00"
+	"1:00:07:52"
+
+	Returns a timedelta object of the appropriate duration, or None if the parse fails
+	"""
+	if s is None:
+		return None
+	match = re_timefmt1.match(s)
+	if not match:
+		match = re_timefmt2.match(s)
+	if not match:
+		return None
+	d = int(match.group(1) or 0)
+	h = int(match.group(2) or 0)
+	m = int(match.group(3) or 0)
+	s = int(match.group(4) or 0)
+	return datetime.timedelta(days=d, hours=h, minutes=m, seconds=s)
+
+
+def strtotime(s):
+	if isinstance(s, str):
+		s = s.encode("utf-8")
+	return datetime.datetime.fromtimestamp(timelib.strtotime(s), tz=pytz.utc)
+
+
+def strtodate(s):
+	dt = strtotime(s)
+	# if the time is exactly midnight, then the user probably entered a date
+	# without time info (eg "yesterday"), so just return that date. Otherwise, they
+	# did enter time info (eg "now") so convert timezone first
+	if dt.time() != datetime.time(0):
+		dt = dt.astimezone(config.config['timezone'])
+	return dt.date()

--- a/common/url.py
+++ b/common/url.py
@@ -1,9 +1,11 @@
 import asyncio
+import logging
 import re
 
 from common.http import request_coro
-from common.utils import cache, log
+from common.utils import cache
 
+log = logging.getLogger("common.url")
 
 @cache(60 * 60, params=[0])
 @asyncio.coroutine
@@ -25,7 +27,6 @@ def canonical_url(url, depth=10):
 			break
 	return urls
 
-
 @cache(24 * 60 * 60)
 @asyncio.coroutine
 def get_tlds():
@@ -38,7 +39,6 @@ def get_tlds():
 			line = line.encode("ascii").decode("idna")
 			tlds.add(line)
 	return tlds
-
 
 @cache(24 * 60 * 60)
 @asyncio.coroutine
@@ -54,11 +54,9 @@ def url_regex():
 	re_url = re_url + "|" + "|".join(map(lambda parens: re.escape(parens[0]) + re_url + re.escape(parens[1]), parens))
 	return re.compile(re_url, re.IGNORECASE)
 
-
 RE_PROTO = re.compile("^https?://")
 def https(uri):
 	return RE_PROTO.sub("https://", uri)
-
 
 def noproto(uri):
 	return RE_PROTO.sub("//", uri)

--- a/common/url.py
+++ b/common/url.py
@@ -1,0 +1,64 @@
+import asyncio
+import re
+
+from common.http import http_request_coro
+from common.utils import cache, log
+
+
+@cache(60 * 60, params=[0])
+@asyncio.coroutine
+def canonical_url(url, depth=10):
+	urls = []
+	while depth > 0:
+		if not url.startswith("http://") and not url.startswith("https://"):
+			url = "http://" + url
+		urls.append(url)
+		try:
+			res = yield from http_request_coro(url, method="HEAD", allow_redirects=False)
+			if res.status in range(300, 400) and "Location" in res.headers:
+				url = res.headers["Location"]
+				depth -= 1
+			else:
+				break
+		except Exception:
+			log.error("Error fetching %r", url)
+			break
+	return urls
+
+
+@cache(24 * 60 * 60)
+@asyncio.coroutine
+def get_tlds():
+	tlds = set()
+	data = yield from http_request_coro("https://data.iana.org/TLD/tlds-alpha-by-domain.txt")
+	for line in data.splitlines():
+		if not line.startswith("#"):
+			line = line.strip().lower()
+			tlds.add(line)
+			line = line.encode("ascii").decode("idna")
+			tlds.add(line)
+	return tlds
+
+
+@cache(24 * 60 * 60)
+@asyncio.coroutine
+def url_regex():
+	parens = ["()", "[]", "{}", "<>", '""', "''"]
+
+	# Sort TLDs in decreasing order by length to avoid incorrect matches.
+	# For example: if 'co' is before 'com', 'example.com/path' is matched as 'example.co'.
+	tlds = sorted((yield from get_tlds()), key=lambda e: len(e), reverse=True)
+	re_tld = "(?:" + "|".join(map(re.escape, tlds)) + ")"
+	re_hostname = "(?:(?:(?:[\w-]+\.)+" + re_tld + "\.?)|(?:\d{,3}(?:\.\d{,3}){3})|(?:\[[0-9a-fA-F:.]+\]))"
+	re_url = "((?:https?://)?" + re_hostname + "(?::\d+)?(?:/[\x5E\s\u200b]*)?)"
+	re_url = re_url + "|" + "|".join(map(lambda parens: re.escape(parens[0]) + re_url + re.escape(parens[1]), parens))
+	return re.compile(re_url, re.IGNORECASE)
+
+
+RE_PROTO = re.compile("^https?://")
+def https(uri):
+	return RE_PROTO.sub("https://", uri)
+
+
+def noproto(uri):
+	return RE_PROTO.sub("//", uri)

--- a/common/url.py
+++ b/common/url.py
@@ -1,7 +1,7 @@
 import asyncio
 import re
 
-from common.http import http_request_coro
+from common.http import request_coro
 from common.utils import cache, log
 
 
@@ -14,7 +14,7 @@ def canonical_url(url, depth=10):
 			url = "http://" + url
 		urls.append(url)
 		try:
-			res = yield from http_request_coro(url, method="HEAD", allow_redirects=False)
+			res = yield from request_coro(url, method="HEAD", allow_redirects=False)
 			if res.status in range(300, 400) and "Location" in res.headers:
 				url = res.headers["Location"]
 				depth -= 1
@@ -30,7 +30,7 @@ def canonical_url(url, depth=10):
 @asyncio.coroutine
 def get_tlds():
 	tlds = set()
-	data = yield from http_request_coro("https://data.iana.org/TLD/tlds-alpha-by-domain.txt")
+	data = yield from request_coro("https://data.iana.org/TLD/tlds-alpha-by-domain.txt")
 	for line in data.splitlines():
 		if not line.startswith("#"):
 			line = line.strip().lower()

--- a/common/utils.py
+++ b/common/utils.py
@@ -1,5 +1,4 @@
 import asyncio
-import datetime
 import enum
 import functools
 import inspect
@@ -13,7 +12,6 @@ import time
 import flask
 import irc.client
 import psycopg2
-import pytz
 import werkzeug.datastructures
 
 from common import config
@@ -304,24 +302,6 @@ def sse_send_event(endpoint, event=None, data=None, event_id=None):
 	sse.connect(config.config['eventsocket'])
 	sse.send(flask.json.dumps(sse_event).encode("utf-8")+b"\n")
 	sse.close()
-
-
-def error_page(message):
-	from www import login
-	return flask.render_template("error.html", message=message, session=login.load_session(include_url=False))
-
-def timestamp(ts):
-	"""
-	Outputs a given time (either unix timestamp or datetime instance) as a human-readable time
-	and includes tags so that common.js will convert the time on page-load to the user's
-	timezone and preferred date/time format.
-	"""
-	if isinstance(ts, (int, float)):
-		ts = datetime.datetime.fromtimestamp(ts, tz=pytz.utc)
-	elif ts.tzinfo is None:
-		ts = ts.replace(tzinfo=datetime.timezone.utc)
-	ts = ts.astimezone(config.config['timezone'])
-	return flask.Markup("<span class=\"timestamp\" data-timestamp=\"{}\">{:%A, %-d %B, %Y %H:%M:%S %Z}</span>".format(ts.timestamp(), ts))
 
 
 def ucfirst(s):

--- a/common/utils.py
+++ b/common/utils.py
@@ -1,10 +1,8 @@
 import asyncio
-import atexit
 import datetime
 import enum
 import functools
 import inspect
-import json
 import logging
 import os.path
 import random
@@ -13,10 +11,7 @@ import socket
 import textwrap
 import time
 import timelib
-import urllib.parse
-import urllib.request
 
-import aiohttp
 import flask
 import irc.client
 import psycopg2
@@ -24,6 +19,7 @@ import pytz
 import werkzeug.datastructures
 
 from common import config
+from common.http import http_request_coro
 from lrrbot.docstring import parse_docstring, encode_docstring, add_header
 
 log = logging.getLogger('utils')
@@ -273,123 +269,6 @@ def check_exception(future):
 	except:
 		log.exception("Exception in future")
 
-class Request(urllib.request.Request):
-	"""Override the get_method method of Request, adding the "method" field that doesn't exist until Python 3.3"""
-	def __init__(self, *args, method=None, **kwargs):
-		super().__init__(*args, **kwargs)
-		self.method = method
-	def get_method(self):
-		if self.method is not None:
-			return self.method
-		else:
-			return super().get_method()
-
-def http_request(url, data=None, method='GET', maxtries=3, headers={}, timeout=5, **kwargs):
-	"""Download a webpage, with retries on failure."""
-	# Let's be nice.
-	headers["User-Agent"] = "LRRbot/2.0 (https://lrrbot.mrphlip.com/)"
-	if data:
-		if isinstance(data, dict):
-			data = urllib.parse.urlencode(data)
-		if method == 'GET':
-			url = '%s?%s' % (url, data)
-			req = Request(url=url, method='GET', headers=headers, **kwargs)
-		elif method == 'POST':
-			req = Request(url=url, data=data.encode("utf-8"), method='POST', headers=headers, **kwargs)
-		elif method == 'PUT':
-			req = Request(url=url, data=data.encode("utf-8"), method='PUT', headers=headers, **kwargs)
-	else:
-		req = Request(url=url, method='GET', headers=headers, **kwargs)
-
-	firstex = None
-	while True:
-		try:
-			return urllib.request.urlopen(req, timeout=timeout).read().decode("utf-8")
-		except Exception as e:
-			maxtries -= 1
-			if firstex is None:
-				firstex = e
-			if maxtries > 0:
-				log.info("Downloading %s failed: %s: %s, retrying...", url, e.__class__.__name__, e)
-			else:
-				break
-	raise firstex
-
-# Limit the number of parallel HTTP connections to a server.
-http_request_session = aiohttp.ClientSession(connector=aiohttp.TCPConnector(limit=6))
-atexit.register(http_request_session.close)
-@asyncio.coroutine
-def http_request_coro(url, data=None, method='GET', maxtries=3, headers={}, timeout=5, allow_redirects=True):
-	headers["User-Agent"] = "LRRbot/2.0 (https://lrrbot.mrphlip.com/)"
-	firstex = None
-
-	# FIXME(#130): aiohttp fails to decode HEAD requests with Content-Encoding set. Do GET requests instead.
-	real_method = method
-	if method == 'HEAD':
-		real_method = 'GET'
-
-	if method == 'GET':
-		params = data
-		data = None
-	else:
-		params = None
-	while True:
-		try:
-			res = yield from asyncio.wait_for(http_request_session.request(real_method, url, params=params, data=data, headers=headers, allow_redirects=allow_redirects), timeout)
-			if method == "HEAD":
-				yield from res.release()
-				return res
-			status_class = res.status // 100
-			if status_class != 2:
-				yield from res.read()
-				if status_class == 4:
-					maxtries = 1
-				yield from res.release()
-				raise urllib.error.HTTPError(res.url, res.status, res.reason, res.headers, None)
-			text = yield from res.text()
-			yield from res.release()
-			return text
-		except Exception as e:
-			maxtries -= 1
-			if firstex is None:
-				firstex = e
-			if maxtries > 0:
-				log.info("Downloading %s failed: %s: %s, retrying...", url, e.__class__.__name__, e)
-			else:
-				break
-	raise firstex
-
-def api_request(uri, *args, **kwargs):
-	# Send the information to the server
-	try:
-		res = http_request(config.config['siteurl'] + uri, *args, **kwargs)
-	except:
-		log.exception("Error at server in %s" % uri)
-	else:
-		try:
-			res = json.loads(res)
-		except:
-			log.exception("Error parsing server response from %s: %s", uri, res)
-		else:
-			if 'success' not in res:
-				log.error("Error at server in %s" % uri)
-			return res
-
-@asyncio.coroutine
-def api_request_coro(uri, *args, **kwargs):
-	try:
-		res = yield from http_request_coro(config.config['siteurl'] + uri, *args, **kwargs)
-	except:
-		log.exception("Error at server in %s" % uri)
-	else:
-		try:
-			res = json.loads(res)
-		except:
-			log.exception("Error parsing server response from %s: %s", uri, res)
-		else:
-			if 'success' not in res:
-				log.error("Error at server in %s" % uri)
-			return res
 
 def nice_duration(s, detail=1):
 	"""

--- a/common/utils.py
+++ b/common/utils.py
@@ -19,7 +19,6 @@ import pytz
 import werkzeug.datastructures
 
 from common import config
-from common.http import http_request_coro
 from lrrbot.docstring import parse_docstring, encode_docstring, add_header
 
 log = logging.getLogger('utils')
@@ -455,58 +454,6 @@ def weighted_choice(options):
 			left = mid
 	return values[left]
 
-@cache(60 * 60, params=[0])
-@asyncio.coroutine
-def canonical_url(url, depth=10):
-	urls = []
-	while depth > 0:
-		if not url.startswith("http://") and not url.startswith("https://"):
-			url = "http://" + url
-		urls.append(url)
-		try:
-			res = yield from http_request_coro(url, method="HEAD", allow_redirects=False)
-			if res.status in range(300, 400) and "Location" in res.headers:
-				url = res.headers["Location"]
-				depth -= 1
-			else:
-				break
-		except Exception:
-			log.error("Error fetching %r", url)
-			break
-	return urls
-
-@cache(24 * 60 * 60)
-@asyncio.coroutine
-def get_tlds():
-	tlds = set()
-	data = yield from http_request_coro("https://data.iana.org/TLD/tlds-alpha-by-domain.txt")
-	for line in data.splitlines():
-		if not line.startswith("#"):
-			line = line.strip().lower()
-			tlds.add(line)
-			line = line.encode("ascii").decode("idna")
-			tlds.add(line)
-	return tlds
-
-@cache(24 * 60 * 60)
-@asyncio.coroutine
-def url_regex():
-	parens = ["()", "[]", "{}", "<>", '""', "''"]
-
-	# Sort TLDs in decreasing order by length to avoid incorrect matches.
-	# For example: if 'co' is before 'com', 'example.com/path' is matched as 'example.co'.
-	tlds = sorted((yield from get_tlds()), key=lambda e: len(e), reverse=True)
-	re_tld = "(?:" + "|".join(map(re.escape, tlds)) + ")"
-	re_hostname = "(?:(?:(?:[\w-]+\.)+" + re_tld + "\.?)|(?:\d{,3}(?:\.\d{,3}){3})|(?:\[[0-9a-fA-F:.]+\]))"
-	re_url = "((?:https?://)?" + re_hostname + "(?::\d+)?(?:/[\x5E\s\u200b]*)?)"
-	re_url = re_url + "|" + "|".join(map(lambda parens: re.escape(parens[0]) + re_url + re.escape(parens[1]), parens))
-	return re.compile(re_url, re.IGNORECASE)
-
-RE_PROTO = re.compile("^https?://")
-def https(uri):
-	return RE_PROTO.sub("https://", uri)
-def noproto(uri):
-	return RE_PROTO.sub("//", uri)
 
 def escape_like(s):
 	return s.replace('\\', '\\\\').replace('%', '\\%').replace('_', '\\_')

--- a/common/utils.py
+++ b/common/utils.py
@@ -1,6 +1,7 @@
 import asyncio
 import functools
 import inspect
+import itertools
 import json
 import logging
 import os.path
@@ -296,3 +297,22 @@ def weighted_choice(options):
 		else:
 			left = mid
 	return values[left]
+
+def pick_random_elements(iterable, k):
+	"""
+	Pick `k` random elements from `iterable`. Returns a list of length `k`.
+	If there weren't enough elements, `None` is stored at that index instead.
+	"""
+	# Algorithm R: https://en.wikipedia.org/wiki/Reservoir_sampling#Algorithm_R
+	# Changed to use zero-based indexing.
+	ret = [None] * k
+	iterable = enumerate(iterable)
+	for i, elem in itertools.islice(iterable, len(ret)):
+		ret[i] = elem
+
+	for i, elem in iterable:
+		j = random.randrange(i)
+		if j < k:
+			ret[j] = elem
+
+	return ret

--- a/common/utils.py
+++ b/common/utils.py
@@ -122,7 +122,7 @@ class Visibility(enum.Enum):
 	PRIVATE = 1
 	PUBLIC = 2
 
-class _throttle_base(object):
+class throttle_base(object):
 	"""Prevent a function from being called more often than once per period"""
 	def __init__(self, period=DEFAULT_THROTTLE, notify=Visibility.SILENT, modoverride=False, params=[], log=True, count=1, allowprivate=False):
 		self.period = period
@@ -208,21 +208,8 @@ class _throttle_base(object):
 		self.lastrun = {}
 		self.lastreturn = {}
 
-class throttle(_throttle_base):
-	"""Prevent an event function from being called more often than once per period
 
-	Usage:
-	@throttle([period])
-	def func(lrrbot, conn, event, ...):
-		...
-
-	count allows the function to be called a given number of times during the period,
-	but no more.
-	"""
-	def __init__(self, period=DEFAULT_THROTTLE, notify=Visibility.PRIVATE, modoverride=True, params=[], log=True, count=1, allowprivate=True):
-		super().__init__(period=period, notify=notify, modoverride=modoverride, params=params, log=log, count=count, allowprivate=allowprivate)
-
-class cache(_throttle_base):
+class cache(throttle_base):
 	"""Cache the results of a function for a given period
 
 	Usage:
@@ -242,111 +229,6 @@ class cache(_throttle_base):
 	def __init__(self, period=DEFAULT_THROTTLE, params=[], log=False, count=1):
 		super().__init__(period=period, notify=Visibility.SILENT, modoverride=False, params=params, log=log, count=count, allowprivate=False)
 
-@coro_decorator
-def mod_only(func):
-	"""Prevent an event-handler function from being called by non-moderators
-
-	Usage:
-	@mod_only
-	def on_event(self, conn, event, ...):
-		...
-	"""
-
-	# Only complain about non-mods with throttle
-	# but allow the command itself to be run without throttling
-	@throttle(notify=Visibility.SILENT, modoverride=False)
-	def mod_complaint(self, conn, event):
-		source = irc.client.NickMask(event.source)
-		if irc.client.is_channel(event.target):
-			respond_to = event.target
-		else:
-			respond_to = source.nick
-		conn.privmsg(respond_to, "%s: That is a mod-only command" % source.nick)
-
-	@functools.wraps(func)
-	@asyncio.coroutine
-	def wrapper(self, conn, event, *args, **kwargs):
-		if self.is_mod(event):
-			return (yield from func(self, conn, event, *args, **kwargs))
-		else:
-			log.info("Refusing %s due to not-a-mod" % func.__name__)
-			mod_complaint(self, conn, event)
-			return None
-	wrapper.__doc__ = encode_docstring(add_header(parse_docstring(wrapper.__doc__),
-		"Mod-Only", "true"))
-	return wrapper
-
-@coro_decorator
-def sub_only(func):
-	"""Prevent an event-handler function from being called by non-subscribers
-
-	Usage:
-	@sub_only
-	def on_event(self, conn, event, ...):
-		...
-	"""
-
-	@throttle(notify=Visibility.SILENT, modoverride=False)
-	def sub_complaint(self, conn, event):
-		source = irc.client.NickMask(event.source)
-		if irc.client.is_channel(event.target):
-			respond_to = event.target
-		else:
-			respond_to = source.nick
-		conn.privmsg(respond_to, "%s: That is a subscriber-only command" % source.nick)
-
-	@functools.wraps(func)
-	@asyncio.coroutine
-	def wrapper(self, conn, event, *args, **kwargs):
-		if self.is_sub(event) or self.is_mod(event):
-			return (yield from func(self, conn, event, *args, **kwargs))
-		else:
-			log.info("Refusing %s due to not-a-sub" % func.__name__)
-			sub_complaint(self, conn, event)
-			return None
-	wrapper.__doc__ = encode_docstring(add_header(parse_docstring(wrapper.__doc__),
-		"Sub-Only", "true"))
-	return wrapper
-
-class twitch_throttle:
-	def __init__(self, count=20, period=30):
-		self.count = count
-		self.period = period
-		self.timestamps = []
-	
-	def __call__(self, f):
-		@functools.wraps(f, assigned=functools.WRAPPER_ASSIGNMENTS + ("is_logged",))
-		def wrapper(*args, **kwargs):
-			now = time.time()
-			self.timestamps = [t for t in self.timestamps if now-t <= self.period]
-			if len(self.timestamps) >= self.count:
-				log.info("Ignoring {}(*{}, **{})".format(f.__name__, args, kwargs))
-			else:
-				self.timestamps.append(now)
-				return f(*args, **kwargs)
-		wrapper.is_throttled = True
-		return wrapper
-
-@coro_decorator
-def public_only(func):
-	"""Prevent an event-handler function from being called via private message
-
-	Usage:
-	@public_only
-	def on_event(self, conn, event, ...):
-		...
-	"""
-	@functools.wraps(func)
-	@asyncio.coroutine
-	def wrapper(self, conn, event, *args, **kwargs):
-		if event.type == "pubmsg" or self.is_mod(event):
-			return (yield from func(self, conn, event, *args, **kwargs))
-		else:
-			source = irc.client.NickMask(event.source)
-			conn.privmsg(source.nick, "That command cannot be used via private message")
-	wrapper.__doc__ = encode_docstring(add_header(parse_docstring(wrapper.__doc__),
-		"Public-Only", "true"))
-	return wrapper
 
 @coro_decorator
 def log_errors(func):

--- a/common/utils.py
+++ b/common/utils.py
@@ -1,6 +1,7 @@
 import asyncio
 import functools
 import inspect
+import json
 import logging
 import os.path
 import random
@@ -8,7 +9,6 @@ import socket
 import textwrap
 import time
 
-import flask
 import werkzeug.datastructures
 
 from common import config
@@ -259,7 +259,7 @@ def sse_send_event(endpoint, event=None, data=None, event_id=None):
 
 	sse = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
 	sse.connect(config.config['eventsocket'])
-	sse.send(flask.json.dumps(sse_event).encode("utf-8")+b"\n")
+	sse.send(json.dumps(sse_event).encode("utf-8")+b"\n")
 	sse.close()
 
 def ucfirst(s):

--- a/common/utils.py
+++ b/common/utils.py
@@ -1,38 +1,33 @@
-import functools
-import socket
-import time
-import logging
-import urllib.request
-import urllib.parse
-import json
-import email.parser
-import textwrap
-import datetime
-import re
-import os.path
-import timelib
-import random
-import enum
 import asyncio
-import aiohttp
 import atexit
+import datetime
+import enum
+import functools
 import inspect
+import json
+import logging
+import os.path
+import random
+import re
+import socket
+import textwrap
+import time
+import timelib
+import urllib.parse
+import urllib.request
 
+import aiohttp
 import flask
 import irc.client
+import psycopg2
 import pytz
 import werkzeug.datastructures
 
 from common import config
-import psycopg2
-
+from lrrbot.docstring import parse_docstring, encode_docstring, add_header
 
 log = logging.getLogger('utils')
 
-DOCSTRING_IMPLICIT_PREFIX = """Content-Type: multipart/message; boundary=command
-
---command"""
-DOCSTRING_IMPLICIT_SUFFIX = "\n--command--"
 
 def deindent(s):
 	def skipblank():
@@ -44,23 +39,6 @@ def deindent(s):
 		yield from generator
 	return "\n".join(skipblank())
 
-def parse_docstring(docstring):
-	if docstring is None:
-		docstring = ""
-	docstring = DOCSTRING_IMPLICIT_PREFIX + docstring + DOCSTRING_IMPLICIT_SUFFIX
-	return email.parser.Parser().parsestr(deindent(docstring))
-
-def encode_docstring(docstring):
-	docstring = str(docstring).rstrip()
-	assert docstring.startswith(DOCSTRING_IMPLICIT_PREFIX)
-	assert docstring.endswith(DOCSTRING_IMPLICIT_SUFFIX)
-	return docstring[len(DOCSTRING_IMPLICIT_PREFIX):-len(DOCSTRING_IMPLICIT_SUFFIX)]
-
-def add_header(doc, name, value):
-	for part in doc.walk():
-		if part.get_content_maintype() != "multipart":
-			part[name] = value
-	return doc
 
 def shorten_fallback(text, width, **kwargs):
 	"""textwrap.shorten is introduced in Python 3.4"""

--- a/common/utils.py
+++ b/common/utils.py
@@ -15,7 +15,6 @@ from common import config
 
 log = logging.getLogger('utils')
 
-
 def deindent(s):
 	def skipblank():
 		generator = map(lambda s: s.lstrip(), s.splitlines())
@@ -25,7 +24,6 @@ def deindent(s):
 		yield line
 		yield from generator
 	return "\n".join(skipblank())
-
 
 def shorten_fallback(text, width, **kwargs):
 	"""textwrap.shorten is introduced in Python 3.4"""
@@ -42,7 +40,6 @@ def shorten_fallback(text, width, **kwargs):
 	else:
 		r = r[0]
 	return r
-
 shorten = getattr(textwrap, "shorten", shorten_fallback)
 
 def coro_decorator(decorator):
@@ -103,8 +100,6 @@ def coro_decorator(decorator):
 	return wrapper
 
 DEFAULT_THROTTLE = 15
-
-
 class throttle_base(object):
 	"""Prevent a function from being called more often than once per period"""
 	def __init__(self, period=DEFAULT_THROTTLE, params=[], log=True, count=1):
@@ -148,7 +143,6 @@ class throttle_base(object):
 		if self.log:
 			log.info("Skipping %s due to throttling" % func.__name__)
 
-
 	def decorate(self, func):
 		if self.watchparams:
 			self.signature = inspect.signature(func)
@@ -180,7 +174,6 @@ class throttle_base(object):
 		self.lastrun = {}
 		self.lastreturn = {}
 
-
 class cache(throttle_base):
 	"""Cache the results of a function for a given period
 
@@ -200,7 +193,6 @@ class cache(throttle_base):
 	"""
 	def __init__(self, period=DEFAULT_THROTTLE, params=[], log=False, count=1):
 		super().__init__(period=period, params=params, log=log, count=count)
-
 
 @coro_decorator
 def log_errors(func):
@@ -245,7 +237,6 @@ def check_exception(future):
 	except:
 		log.exception("Exception in future")
 
-
 def immutable(obj):
 	if isinstance(obj, dict):
 		return werkzeug.datastructures.ImmutableDict((k, immutable(v)) for k,v in obj.items())
@@ -253,7 +244,6 @@ def immutable(obj):
 		return werkzeug.datastructures.ImmutableList(immutable(v) for v in obj)
 	else:
 		return obj
-
 
 def sse_send_event(endpoint, event=None, data=None, event_id=None):
 	if not os.path.exists(config.config['eventsocket']):
@@ -272,10 +262,8 @@ def sse_send_event(endpoint, event=None, data=None, event_id=None):
 	sse.send(flask.json.dumps(sse_event).encode("utf-8")+b"\n")
 	sse.close()
 
-
 def ucfirst(s):
 	return s[0].upper() + s[1:]
-
 
 def weighted_choice(options):
 	"""
@@ -308,5 +296,3 @@ def weighted_choice(options):
 		else:
 			left = mid
 	return values[left]
-
-

--- a/common/utils.py
+++ b/common/utils.py
@@ -6,11 +6,9 @@ import inspect
 import logging
 import os.path
 import random
-import re
 import socket
 import textwrap
 import time
-import timelib
 
 import flask
 import irc.client
@@ -269,44 +267,6 @@ def check_exception(future):
 		log.exception("Exception in future")
 
 
-def nice_duration(s, detail=1):
-	"""
-	Convert a duration in seconds to a human-readable duration.
-
-	detail can be:
-		0 - Always show to the nearest second
-		1 - Show to the nearest minute, unless less than a minute
-		2 - Show to the nearest hour, unless less than an hour
-	"""
-	if isinstance(s, datetime.timedelta):
-		s = s.days * 86400 + s.seconds
-	if s < 0:
-		return "-" + nice_duration(-s, detail)
-	if s < 60:
-		return ["0:%(s)02d", "%(s)ds", "%(s)ds"][detail] % {'s': s}
-	m, s = divmod(s, 60)
-	if m < 60:
-		return ["%(m)d:%(s)02d", "%(m)dm", "%(m)dm"][detail] % {'s': s, 'm': m}
-	h, m = divmod(m, 60)
-	if h < 24:
-		return ["%(h)d:%(m)02d:%(s)02d", "%(h)d:%(m)02d", "%(h)dh"][detail] % {'s': s, 'm': m, 'h': h}
-	d, h = divmod(h, 24)
-	return ["%(d)dd, %(h)d:%(m)02d:%(s)02d", "%(d)dd, %(h)d:%(m)02d", "%(d)dd, %(h)dh"][detail] % {'s': s, 'm': m, 'h': h, 'd': d}
-
-def get_timezone(tz):
-	"""
-	Look up a timezone by name, case-insensitively
-	"""
-	try:
-		return pytz.timezone(tz)
-	except pytz.exceptions.UnknownTimeZoneError:
-		tznames = {i.lower(): i for i in pytz.all_timezones}
-		tz = tz.lower()
-		if tz in tznames:
-			return pytz.timezone(tznames[tz])
-		else:
-			raise
-
 def immutable(obj):
 	if isinstance(obj, dict):
 		return werkzeug.datastructures.ImmutableDict((k, immutable(v)) for k,v in obj.items())
@@ -367,49 +327,6 @@ def timestamp(ts):
 def ucfirst(s):
 	return s[0].upper() + s[1:]
 
-re_timefmt1 = re.compile("^\s*(?:\s*(\d*)\s*d)?(?:\s*(\d*)\s*h)?(?:\s*(\d*)\s*m)?(?:\s*(\d*)\s*s?)?\s*$")
-re_timefmt2 = re.compile("^(?:(?:(?:\s*(\d*)\s*:)?\s*(\d*)\s*:)?\s*(\d*)\s*:)?\s*(\d*)\s*$")
-def parsetime(s):
-	"""
-	Parse user-supplied times in one of two formats:
-	"10s"
-	"5m3s"
-	"7h2m"
-	"1d7m52s"
-	or:
-	"10"
-	"5:03"
-	"7:02:00"
-	"1:00:07:52"
-
-	Returns a timedelta object of the appropriate duration, or None if the parse fails
-	"""
-	if s is None:
-		return None
-	match = re_timefmt1.match(s)
-	if not match:
-		match = re_timefmt2.match(s)
-	if not match:
-		return None
-	d = int(match.group(1) or 0)
-	h = int(match.group(2) or 0)
-	m = int(match.group(3) or 0)
-	s = int(match.group(4) or 0)
-	return datetime.timedelta(days=d, hours=h, minutes=m, seconds=s)
-
-def strtotime(s):
-	if isinstance(s, str):
-		s = s.encode("utf-8")
-	return datetime.datetime.fromtimestamp(timelib.strtotime(s), tz=pytz.utc)
-
-def strtodate(s):
-	dt = strtotime(s)
-	# if the time is exactly midnight, then the user probably entered a date
-	# without time info (eg "yesterday"), so just return that date. Otherwise, they
-	# did enter time info (eg "now") so convert timezone first
-	if dt.time() != datetime.time(0):
-		dt = dt.astimezone(config.config['timezone'])
-	return dt.date()
 
 def pick_random_row(cur, query, params = ()):
 	" Return a random row of a SELECT query. "

--- a/highlights.py
+++ b/highlights.py
@@ -2,7 +2,7 @@
 import common.postgres
 from lrrbot import twitch
 from common.highlights import SPREADSHEET, format_row
-from common import utils, gdata
+from common import gdata
 
 import dateutil.parser
 import asyncio

--- a/highlights.py
+++ b/highlights.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-
+import common.postgres
 from lrrbot import twitch
 from common.highlights import SPREADSHEET, format_row
 from common import utils, gdata
@@ -7,7 +7,7 @@ from common import utils, gdata
 import dateutil.parser
 import asyncio
 
-@utils.with_postgres
+@common.postgres.with_postgres
 def get_staged_highlights(conn, cur):
 	cur.execute("SELECT id, title, description, time, nick FROM highlights")
 	return [{
@@ -18,7 +18,7 @@ def get_staged_highlights(conn, cur):
 		"nick": highlight[4],
 	} for highlight in cur]
 
-@utils.with_postgres
+@common.postgres.with_postgres
 def delete_staged_highlights(conn, cur, highlights):
 	cur.executemany("DELETE FROM highlights WHERE id = %s", [(highlight["id"], ) for highlight in highlights])
 

--- a/lrrbot/chatlog.py
+++ b/lrrbot/chatlog.py
@@ -239,7 +239,7 @@ def build_message_html(time, source, target, message, specialuser, usercolor, em
 @asyncio.coroutine
 def get_display_name(nick):
 	try:
-		data = yield from common.http.http_request_coro("https://api.twitch.tv/kraken/users/%s" % nick)
+		data = yield from common.http.request_coro("https://api.twitch.tv/kraken/users/%s" % nick)
 		data = json.loads(data)
 		return data['display_name']
 	except:
@@ -248,7 +248,7 @@ def get_display_name(nick):
 re_just_words = re.compile("^\w+$")
 @asyncio.coroutine
 def get_twitch_emotes_official():
-	data = yield from common.http.http_request_coro("https://api.twitch.tv/kraken/chat/emoticons")
+	data = yield from common.http.request_coro("https://api.twitch.tv/kraken/chat/emoticons")
 	data = json.loads(data)['emoticons']
 	emotesets = {}
 	for emote in data:
@@ -273,7 +273,7 @@ def get_twitch_emotes_official():
 @asyncio.coroutine
 def get_twitch_emotes_undocumented():
 	# This endpoint is not documented, however `/chat/emoticons` might be deprecated soon.
-	data = yield from common.http.http_request_coro("https://api.twitch.tv/kraken/chat/emoticon_images")
+	data = yield from common.http.request_coro("https://api.twitch.tv/kraken/chat/emoticon_images")
 	data = json.loads(data)["emoticons"]
 	emotesets = {}
 	for emote in data:

--- a/lrrbot/chatlog.py
+++ b/lrrbot/chatlog.py
@@ -1,7 +1,6 @@
 import queue
 import json
 import re
-import time
 import pytz
 import datetime
 import logging
@@ -15,7 +14,6 @@ import common.postgres
 import common.url
 from common import utils
 from common.config import config
-
 
 __all__ = ["log_chat", "clear_chat_log", "exitthread"]
 
@@ -42,7 +40,6 @@ def run_task():
 		elif ev == "exit":
 			break
 
-
 def log_chat(event, metadata):
 	queue.put_nowait(("log_chat", (datetime.datetime.now(pytz.utc), event, metadata)))
 
@@ -54,7 +51,6 @@ def rebuild_all():
 
 def stop_task():
 	queue.put_nowait(("exit", ()))
-
 
 @utils.swallow_errors
 @asyncio.coroutine

--- a/lrrbot/chatlog.py
+++ b/lrrbot/chatlog.py
@@ -10,6 +10,7 @@ import asyncio
 import irc.client
 from jinja2.utils import Markup, escape, urlize
 
+import common.http
 from common import utils
 from common.config import config
 
@@ -236,7 +237,7 @@ def build_message_html(time, source, target, message, specialuser, usercolor, em
 @asyncio.coroutine
 def get_display_name(nick):
 	try:
-		data = yield from utils.http_request_coro("https://api.twitch.tv/kraken/users/%s" % nick)
+		data = yield from common.http.http_request_coro("https://api.twitch.tv/kraken/users/%s" % nick)
 		data = json.loads(data)
 		return data['display_name']
 	except:
@@ -245,7 +246,7 @@ def get_display_name(nick):
 re_just_words = re.compile("^\w+$")
 @asyncio.coroutine
 def get_twitch_emotes_official():
-	data = yield from utils.http_request_coro("https://api.twitch.tv/kraken/chat/emoticons")
+	data = yield from common.http.http_request_coro("https://api.twitch.tv/kraken/chat/emoticons")
 	data = json.loads(data)['emoticons']
 	emotesets = {}
 	for emote in data:
@@ -269,7 +270,7 @@ def get_twitch_emotes_official():
 @asyncio.coroutine
 def get_twitch_emotes_undocumented():
 	# This endpoint is not documented, however `/chat/emoticons` might be deprecated soon.
-	data = yield from utils.http_request_coro("https://api.twitch.tv/kraken/chat/emoticon_images")
+	data = yield from common.http.http_request_coro("https://api.twitch.tv/kraken/chat/emoticon_images")
 	data = json.loads(data)["emoticons"]
 	emotesets = {}
 	for emote in data:

--- a/lrrbot/chatlog.py
+++ b/lrrbot/chatlog.py
@@ -11,6 +11,7 @@ import irc.client
 from jinja2.utils import Markup, escape, urlize
 
 import common.http
+import common.url
 from common import utils
 from common.config import config
 
@@ -260,7 +261,8 @@ def get_twitch_emotes_official():
 		for image in emote['images']:
 			if image['url'] is None:
 				continue
-			html = '<img src="%s" width="%d" height="%d" alt="{0}" title="{0}">' % (utils.https(image['url']), image['width'], image['height'])
+			html = '<img src="%s" width="%d" height="%d" alt="{0}" title="{0}">' % (
+			common.url.https(image['url']), image['width'], image['height'])
 			emotesets.setdefault(image.get("emoticon_set"), {})[emote['regex']] = {
 				"regex": regex,
 				"html": html,

--- a/lrrbot/commands/card.py
+++ b/lrrbot/commands/card.py
@@ -2,9 +2,7 @@ import json
 import re
 
 import lrrbot.decorators
-from common import utils
 from lrrbot.main import bot
-
 
 with open("mtgcards.json") as fp:
 	# format:

--- a/lrrbot/commands/card.py
+++ b/lrrbot/commands/card.py
@@ -1,6 +1,7 @@
 import json
 import re
 
+import lrrbot.decorators
 from common import utils
 from lrrbot.main import bot
 
@@ -13,7 +14,7 @@ with open("mtgcards.json") as fp:
 	CARD_DATA = json.load(fp)
 
 @bot.command("card (.+)")
-@utils.throttle(60, count=3)
+@lrrbot.decorators.throttle(60, count=3)
 def card_lookup(lrrbot, conn, event, respond_to, search):
 	"""
 	Command: !card card-name

--- a/lrrbot/commands/explain.py
+++ b/lrrbot/commands/explain.py
@@ -1,10 +1,8 @@
 import random
 
 import lrrbot.decorators
-from common import utils
 from lrrbot import storage
 from lrrbot.main import bot, log
-
 
 @bot.command("explain (.*?)")
 @lrrbot.decorators.throttle(30, params=[4], count=2)

--- a/lrrbot/commands/explain.py
+++ b/lrrbot/commands/explain.py
@@ -1,12 +1,13 @@
 import random
 
+import lrrbot.decorators
 from common import utils
 from lrrbot import storage
 from lrrbot.main import bot, log
 
 
 @bot.command("explain (.*?)")
-@utils.throttle(30, params=[4], count=2)
+@lrrbot.decorators.throttle(30, params=[4], count=2)
 def explain_response(lrrbot, conn, event, respond_to, command):
 	"""
 	Command: !explain TOPIC

--- a/lrrbot/commands/game.py
+++ b/lrrbot/commands/game.py
@@ -3,6 +3,7 @@ import irc
 import lrrbot.decorators
 from common import utils
 from lrrbot import storage
+from lrrbot import twitch
 from lrrbot.main import bot
 from lrrbot.commands.show import show_name
 
@@ -107,7 +108,7 @@ def override_game(lrrbot, conn, event, respond_to, game):
 	else:
 		lrrbot.game_override = game
 		operation = "enabled"
-	lrrbot.get_current_game_real.reset_throttle()
+	twitch.get_game.reset_throttle()
 	current_game.reset_throttle()
 	game = lrrbot.get_current_game()
 	message = "Override %s. " % operation
@@ -126,7 +127,7 @@ def refresh(lrrbot, conn, event, respond_to):
 
 	Force a refresh of the current Twitch game (normally this is updated at most once every 15 minutes)
 	"""
-	lrrbot.get_current_game_real.reset_throttle()
+	twitch.get_game.reset_throttle()
 	current_game.reset_throttle()
 	current_game(lrrbot, conn, event, respond_to)
 

--- a/lrrbot/commands/game.py
+++ b/lrrbot/commands/game.py
@@ -132,7 +132,7 @@ def refresh(lrrbot, conn, event, respond_to):
 
 @bot.command("game completed")
 @lrrbot.decorators.mod_only
-@lrrbot.decorators.throttle(30, notify=utils.Visibility.PUBLIC, modoverride=False, allowprivate=False)
+@lrrbot.decorators.throttle(30, notify=lrrbot.decorators.Visibility.PUBLIC, modoverride=False, allowprivate=False)
 def completed(lrrbot, conn, event, respond_to):
 	"""
 	Command: !game completed

--- a/lrrbot/commands/game.py
+++ b/lrrbot/commands/game.py
@@ -1,5 +1,6 @@
 import irc
 
+import lrrbot.decorators
 from common import utils
 from lrrbot import storage
 from lrrbot.main import bot
@@ -10,7 +11,7 @@ def game_name(game):
 	return game.get("display", game["name"])
 
 @bot.command("game")
-@utils.throttle()
+@lrrbot.decorators.throttle()
 def current_game(lrrbot, conn, event, respond_to):
 	"""
 	Command: !game
@@ -64,7 +65,7 @@ def vote_respond(lrrbot, conn, respond_to, game):
 	lrrbot.vote_update = None
 
 @bot.command("game display (.*?)")
-@utils.mod_only
+@lrrbot.decorators.mod_only
 def set_game_name(lrrbot, conn, event, respond_to, name):
 	"""
 	Command: !game display NAME
@@ -83,7 +84,7 @@ def set_game_name(lrrbot, conn, event, respond_to, name):
 	conn.privmsg(respond_to, "OK, I'll start calling %(name)s \"%(display)s\"" % game)
 
 @bot.command("game override (.*?)")
-@utils.mod_only
+@lrrbot.decorators.mod_only
 def override_game(lrrbot, conn, event, respond_to, game):
 	"""
 	Command: !game override NAME
@@ -117,7 +118,7 @@ def override_game(lrrbot, conn, event, respond_to, game):
 	conn.privmsg(respond_to, message)
 
 @bot.command("game refresh")
-@utils.mod_only
+@lrrbot.decorators.mod_only
 def refresh(lrrbot, conn, event, respond_to):
 	"""
 	Command: !game refresh
@@ -130,8 +131,8 @@ def refresh(lrrbot, conn, event, respond_to):
 	current_game(lrrbot, conn, event, respond_to)
 
 @bot.command("game completed")
-@utils.mod_only
-@utils.throttle(30, notify=utils.Visibility.PUBLIC, modoverride=False, allowprivate=False)
+@lrrbot.decorators.mod_only
+@lrrbot.decorators.throttle(30, notify=utils.Visibility.PUBLIC, modoverride=False, allowprivate=False)
 def completed(lrrbot, conn, event, respond_to):
 	"""
 	Command: !game completed

--- a/lrrbot/commands/game.py
+++ b/lrrbot/commands/game.py
@@ -7,7 +7,6 @@ from lrrbot import twitch
 from lrrbot.main import bot
 from lrrbot.commands.show import show_name
 
-
 def game_name(game):
 	return game.get("display", game["name"])
 

--- a/lrrbot/commands/highlights.py
+++ b/lrrbot/commands/highlights.py
@@ -1,5 +1,6 @@
 import irc.client
 
+import lrrbot.decorators
 from common import utils, gdata
 from common.highlights import SPREADSHEET, format_row
 from lrrbot import twitch
@@ -14,9 +15,9 @@ def store_highlight(conn, cur, title, description, time, nick):
 	cur.execute("INSERT INTO highlights (title, description, time, nick) VALUES(%s, %s, %s, %s)", (title, description, time, nick))
 
 @bot.command("highlight (.*?)")
-@utils.public_only
-@utils.sub_only
-@utils.throttle(60, notify=utils.Visibility.PUBLIC, modoverride=False, allowprivate=False)
+@lrrbot.decorators.public_only
+@lrrbot.decorators.sub_only
+@lrrbot.decorators.throttle(60, notify=utils.Visibility.PUBLIC, modoverride=False, allowprivate=False)
 @asyncio.coroutine
 def highlight(lrrbot, conn, event, respond_to, description):
 	"""

--- a/lrrbot/commands/highlights.py
+++ b/lrrbot/commands/highlights.py
@@ -18,7 +18,7 @@ def store_highlight(conn, cur, title, description, time, nick):
 @bot.command("highlight (.*?)")
 @lrrbot.decorators.public_only
 @lrrbot.decorators.sub_only
-@lrrbot.decorators.throttle(60, notify=utils.Visibility.PUBLIC, modoverride=False, allowprivate=False)
+@lrrbot.decorators.throttle(60, notify=lrrbot.decorators.Visibility.PUBLIC, modoverride=False, allowprivate=False)
 @asyncio.coroutine
 def highlight(lrrbot, conn, event, respond_to, description):
 	"""

--- a/lrrbot/commands/highlights.py
+++ b/lrrbot/commands/highlights.py
@@ -1,5 +1,6 @@
 import irc.client
 
+import common.postgres
 import lrrbot.decorators
 from common import utils, gdata
 from common.highlights import SPREADSHEET, format_row
@@ -10,7 +11,7 @@ import asyncio
 import dateutil.parser
 import datetime
 
-@utils.with_postgres
+@common.postgres.with_postgres
 def store_highlight(conn, cur, title, description, time, nick):
 	cur.execute("INSERT INTO highlights (title, description, time, nick) VALUES(%s, %s, %s, %s)", (title, description, time, nick))
 

--- a/lrrbot/commands/live.py
+++ b/lrrbot/commands/live.py
@@ -1,3 +1,4 @@
+import lrrbot.decorators
 from lrrbot.main import bot
 from lrrbot import twitch
 from lrrbot import googlecalendar
@@ -40,7 +41,7 @@ def extract_new_channels(loop):
 	yield from asyncio.gather(*map(twitch.follow_channel, channels.difference(old_channels)), loop=loop, return_exceptions=True)
 
 @bot.command("live")
-@utils.throttle()
+@lrrbot.decorators.throttle()
 @asyncio.coroutine
 def live(lrrbot, conn, event, respond_to):
 	"""
@@ -120,7 +121,7 @@ def unregister_self(lrrbot, conn, event, respond_to):
 	conn.privmsg(respond_to, "Channel '%s' removed from the fanstreamer list." % channel)
 
 @bot.command("live register (.*)")
-@utils.mod_only
+@lrrbot.decorators.mod_only
 @asyncio.coroutine
 def register(lrrbot, conn, event, respond_to, channel):
 	"""
@@ -135,7 +136,7 @@ def register(lrrbot, conn, event, respond_to, channel):
 		conn.privmsg(respond_to, "'%s' isn't a Twitch channel." % channel)
 
 @bot.command("live unregister (.*)")
-@utils.mod_only
+@lrrbot.decorators.mod_only
 @asyncio.coroutine
 def unregister(lrrbot, conn, event, respond_to, channel):
 	"""

--- a/lrrbot/commands/live.py
+++ b/lrrbot/commands/live.py
@@ -96,7 +96,6 @@ def live(lrrbot, conn, event, respond_to):
 	])
 	return conn.privmsg(respond_to, utils.shorten(message, 450))
 
-
 @bot.command("live register")
 @asyncio.coroutine
 def register_self(lrrbot, conn, event, respond_to):

--- a/lrrbot/commands/live.py
+++ b/lrrbot/commands/live.py
@@ -14,7 +14,7 @@ import irc.client
 @utils.cache(24 * 60 * 60)
 @asyncio.coroutine
 def extract_new_channels(loop):
-	data = yield from common.http.http_request_coro(googlecalendar.EVENTS_URL % urllib.parse.quote(googlecalendar.CALENDAR_FAN), {
+	data = yield from common.http.request_coro(googlecalendar.EVENTS_URL % urllib.parse.quote(googlecalendar.CALENDAR_FAN), {
 		"key": config["google_key"],
 		"maxResults": 25000,
 	})

--- a/lrrbot/commands/live.py
+++ b/lrrbot/commands/live.py
@@ -1,3 +1,4 @@
+import common.http
 import lrrbot.decorators
 from lrrbot.main import bot
 from lrrbot import twitch
@@ -13,7 +14,7 @@ import irc.client
 @utils.cache(24 * 60 * 60)
 @asyncio.coroutine
 def extract_new_channels(loop):
-	data = yield from utils.http_request_coro(googlecalendar.EVENTS_URL % urllib.parse.quote(googlecalendar.CALENDAR_FAN), {
+	data = yield from common.http.http_request_coro(googlecalendar.EVENTS_URL % urllib.parse.quote(googlecalendar.CALENDAR_FAN), {
 		"key": config["google_key"],
 		"maxResults": 25000,
 	})

--- a/lrrbot/commands/lockdown.py
+++ b/lrrbot/commands/lockdown.py
@@ -1,9 +1,10 @@
+import lrrbot.decorators
 from common import utils
 from lrrbot.main import bot
 
 
 @bot.command("(mod|sub)only")
-@utils.mod_only
+@lrrbot.decorators.mod_only
 def mod_only(lrrbot, conn, event, respond_to, level):
 	"""
 	Command: !modonly
@@ -16,7 +17,7 @@ def mod_only(lrrbot, conn, event, respond_to, level):
 	conn.privmsg(respond_to, "Commands from non-%ss are now ignored." % level)
 
 @bot.command("(?:mod|sub)only off")
-@utils.mod_only
+@lrrbot.decorators.mod_only
 def mod_only_off(lrrbot, conn, event, respond_to):
 	"""
 	Command: !modonly off

--- a/lrrbot/commands/lockdown.py
+++ b/lrrbot/commands/lockdown.py
@@ -1,7 +1,5 @@
 import lrrbot.decorators
-from common import utils
 from lrrbot.main import bot
-
 
 @bot.command("(mod|sub)only")
 @lrrbot.decorators.mod_only

--- a/lrrbot/commands/misc.py
+++ b/lrrbot/commands/misc.py
@@ -7,6 +7,7 @@ import dateutil.parser
 import pytz
 import irc.client
 
+import lrrbot.decorators
 from common import utils
 from common.config import config
 from lrrbot import googlecalendar, storage, twitch
@@ -15,12 +16,12 @@ from lrrbot.main import bot
 log = logging.getLogger('misc')
 
 @bot.command("test")
-@utils.mod_only
+@lrrbot.decorators.mod_only
 def test(lrrbot, conn, event, respond_to):
 	conn.privmsg(respond_to, "Test")
 
 @bot.command("storm(?:count)?")
-@utils.throttle()
+@lrrbot.decorators.throttle()
 def stormcount(lrrbot, conn, event, respond_to):
 	"""
 	Command: !storm
@@ -39,7 +40,7 @@ def stormcount(lrrbot, conn, event, respond_to):
 	conn.privmsg(respond_to, "Today's storm count: %d" % storage.data["storm"]["count"])
 
 @bot.command("spam(?:count)?")
-@utils.throttle()
+@lrrbot.decorators.throttle()
 def spamcount(lrrbot, conn, event, respond_to):
 	"""
 	Command: !spam
@@ -63,7 +64,7 @@ DESERTBUS_PRESTART = datetime.datetime(2015, 11, 12, 14, 0, tzinfo=config["timez
 DESERTBUS_END = DESERTBUS_START + datetime.timedelta(days=6)  # Six days of plugs should be long enough
 
 @bot.command("next( .*)?")
-@utils.throttle()
+@lrrbot.decorators.throttle()
 def next(lrrbot, conn, event, respond_to, timezone):
 	"""
 	Command: !next
@@ -82,7 +83,7 @@ def next(lrrbot, conn, event, respond_to, timezone):
 		conn.privmsg(respond_to, googlecalendar.get_next_event_text(googlecalendar.CALENDAR_LRL, tz=timezone))
 
 @bot.command("desert ?bus( .*)?")
-@utils.throttle()
+@lrrbot.decorators.throttle()
 def desertbus(lrrbot, conn, event, respond_to, timezone):
 	if not timezone:
 		timezone = config['timezone']
@@ -106,7 +107,7 @@ def desertbus(lrrbot, conn, event, respond_to, timezone):
 
 
 @bot.command("nextfan( .*)?")
-@utils.throttle()
+@lrrbot.decorators.throttle()
 def nextfan(lrrbot, conn, event, respond_to, timezone):
 	"""
 	Command: !nextfan
@@ -117,7 +118,7 @@ def nextfan(lrrbot, conn, event, respond_to, timezone):
 	conn.privmsg(respond_to, googlecalendar.get_next_event_text(googlecalendar.CALENDAR_FAN, tz=timezone, include_current=True))
 
 @bot.command("time")
-@utils.throttle()
+@lrrbot.decorators.throttle()
 def time(lrrbot, conn, event, respond_to):
 	"""
 	Command: !time
@@ -129,7 +130,7 @@ def time(lrrbot, conn, event, respond_to):
 	conn.privmsg(respond_to, "Current moonbase time: %s" % now.strftime("%l:%M %p"))
 	
 @bot.command("time 24")
-@utils.throttle()
+@lrrbot.decorators.throttle()
 def time24(lrrbot, conn, event, respond_to):
 	"""
 	Command: !time 24
@@ -141,7 +142,7 @@ def time24(lrrbot, conn, event, respond_to):
 	conn.privmsg(respond_to, "Current moonbase time: %s" % now.strftime("%H:%M"))
 
 @bot.command("viewers")
-@utils.throttle(30) # longer cooldown as this involves 2 API calls
+@lrrbot.decorators.throttle(30) # longer cooldown as this involves 2 API calls
 def viewers(lrrbot, conn, event, respond_to):
 	"""
 	Command: !viewers
@@ -184,7 +185,7 @@ def uptime_msg(stream_info=None, factor=1):
 		return "The stream is not live."
 
 @bot.command("(uptime|updog)")
-@utils.throttle()
+@lrrbot.decorators.throttle()
 def uptime(lrrbot, conn, event, respond_to, command):
 	"""
 	Command: !uptime

--- a/lrrbot/commands/misc.py
+++ b/lrrbot/commands/misc.py
@@ -107,7 +107,6 @@ def desertbus(lrrbot, conn, event, respond_to, timezone):
 	else:
 		conn.privmsg(respond_to, "Desert Bus for Hope will return next year, start saving your donation money now!")
 
-
 @bot.command("nextfan( .*)?")
 @lrrbot.decorators.throttle()
 def nextfan(lrrbot, conn, event, respond_to, timezone):
@@ -130,7 +129,7 @@ def time(lrrbot, conn, event, respond_to):
 	"""
 	now = datetime.datetime.now(config["timezone"])
 	conn.privmsg(respond_to, "Current moonbase time: %s" % now.strftime("%l:%M %p"))
-	
+
 @bot.command("time 24")
 @lrrbot.decorators.throttle()
 def time24(lrrbot, conn, event, respond_to):

--- a/lrrbot/commands/misc.py
+++ b/lrrbot/commands/misc.py
@@ -8,6 +8,7 @@ import pytz
 import irc.client
 
 import common.http
+import common.time
 import lrrbot.decorators
 from common import utils
 from common.config import config
@@ -91,14 +92,14 @@ def desertbus(lrrbot, conn, event, respond_to, timezone):
 	else:
 		timezone = timezone.strip()
 		try:
-			timezone = utils.get_timezone(timezone)
+			timezone = common.time.get_timezone(timezone)
 		except pytz.exceptions.UnknownTimeZoneError:
 			conn.privmsg(respond_to, "Unknown timezone: %s" % timezone)
 
 	now = datetime.datetime.now(datetime.timezone.utc)
 
 	if now < DESERTBUS_START:
-		nice_duration = utils.nice_duration(DESERTBUS_START - now, 1) + " from now"
+		nice_duration = common.time.nice_duration(DESERTBUS_START - now, 1) + " from now"
 		conn.privmsg(respond_to, "Desert Bus for Hope will begin at %s (%s)" % (DESERTBUS_START.astimezone(timezone).strftime(
 			googlecalendar.DISPLAY_FORMAT), nice_duration))
 	elif now < DESERTBUS_END:
@@ -179,7 +180,7 @@ def uptime_msg(stream_info=None, factor=1):
 	if stream_info and stream_info.get("stream_created_at"):
 		start = dateutil.parser.parse(stream_info["stream_created_at"])
 		now = datetime.datetime.now(datetime.timezone.utc)
-		return "The stream has been live for %s." % utils.nice_duration((now - start) * factor, 0)
+		return "The stream has been live for %s." % common.time.nice_duration((now - start) * factor, 0)
 	elif stream_info and stream_info.get('live'):
 		return "Twitch won't tell me when the stream went live."
 	else:

--- a/lrrbot/commands/misc.py
+++ b/lrrbot/commands/misc.py
@@ -7,6 +7,7 @@ import dateutil.parser
 import pytz
 import irc.client
 
+import common.http
 import lrrbot.decorators
 from common import utils
 from common.config import config
@@ -159,7 +160,7 @@ def viewers(lrrbot, conn, event, respond_to):
 	# Since we're using TWITCHCLIENT 3, we don't get join/part messages, so we can't just use
 	# len(lrrbot.channels["#loadingreadyrun"].userdict)
 	# as that dict won't be populated. Need to call this api instead.
-	chatters = utils.http_request("https://tmi.twitch.tv/group/user/%s/chatters" % config["channel"])
+	chatters = common.http.http_request("https://tmi.twitch.tv/group/user/%s/chatters" % config["channel"])
 	chatters = json.loads(chatters).get("chatter_count")
 
 	if viewers is not None:

--- a/lrrbot/commands/misc.py
+++ b/lrrbot/commands/misc.py
@@ -161,7 +161,7 @@ def viewers(lrrbot, conn, event, respond_to):
 	# Since we're using TWITCHCLIENT 3, we don't get join/part messages, so we can't just use
 	# len(lrrbot.channels["#loadingreadyrun"].userdict)
 	# as that dict won't be populated. Need to call this api instead.
-	chatters = common.http.http_request("https://tmi.twitch.tv/group/user/%s/chatters" % config["channel"])
+	chatters = common.http.request("https://tmi.twitch.tv/group/user/%s/chatters" % config["channel"])
 	chatters = json.loads(chatters).get("chatter_count")
 
 	if viewers is not None:

--- a/lrrbot/commands/quote.py
+++ b/lrrbot/commands/quote.py
@@ -21,6 +21,7 @@
 # SOFTWARE.
 import common.postgres
 import common.time
+import common.utils
 import lrrbot.decorators
 from lrrbot.main import bot
 
@@ -62,11 +63,12 @@ def quote(pg_conn, cur, lrrbot, conn, event, respond_to, qid, attrib):
 			WHERE NOT deleted
 		""", ()
 
-	row = common.postgres.pick_random_row(cur, """
+	cur.execute("""
 		SELECT qid, quote, attrib_name, attrib_date
 		FROM quotes
 		%s
 	""" % where, params)
+	row = common.utils.pick_random_elements(cur, 1)[0]
 	if row is None:
 		conn.privmsg(respond_to, "Could not find any matching quotes.")
 		return
@@ -165,13 +167,14 @@ def findquote(pg_conn, cur, lrrbot, conn, event, respond_to, query):
 	Search for a quote in the quote database.
 	"""
 
-	row = common.postgres.pick_random_row(cur, """
+	cur.execute("""
 		SELECT qid, quote, attrib_name, attrib_date
 		FROM quotes
 		WHERE
 			TO_TSVECTOR('english', quote) @@ PLAINTO_TSQUERY('english', %s)
 			AND NOT deleted
 	""", (query, ))
+	row = common.utils.pick_random_elements(cur, 1)[0]
 	if row is None:
 		return conn.privmsg(respond_to, "Could not find any matching quotes.")
 	qid, quote, name, date = row

--- a/lrrbot/commands/quote.py
+++ b/lrrbot/commands/quote.py
@@ -26,6 +26,14 @@ from common import utils
 from lrrbot.main import bot
 import datetime
 
+def format_quote(tag, qid, quote, name, date):
+	quote_msg = "{tag} #{qid}: \"{quote}\"".format(tag=tag, qid=qid, quote=quote)
+	if name:
+		quote_msg += " —{name}".format(name=name)
+	if date:
+		quote_msg += " [{date!s}]".format(date=date)
+	return quote_msg
+
 @bot.command("quote(?: (?:(\d+)|(.+)))?")
 @lrrbot.decorators.sub_only
 @lrrbot.decorators.throttle(60, count=2)
@@ -66,13 +74,7 @@ def quote(pg_conn, cur, lrrbot, conn, event, respond_to, qid, attrib):
 		return
 
 	qid, quote, name, date = row
-
-	quote_msg = "Quote #{qid}: \"{quote}\"".format(qid=qid, quote=quote)
-	if name:
-		quote_msg += " —{name}".format(name=name)
-	if date:
-		quote_msg += " [{date!s}]".format(date=date)
-	conn.privmsg(respond_to, quote_msg)
+	conn.privmsg(respond_to, format_quote("Quote", qid, quote, name, date))
 
 @bot.command("addquote(?: \((.+?)\))?(?: \[(.+?)\])? (.+)")
 @lrrbot.decorators.mod_only
@@ -100,13 +102,7 @@ def addquote(pg_conn, cur, lrrbot, conn, event, respond_to, name, date, quote):
 	""", (quote, name, date))
 	qid, = next(cur)
 
-	quote_msg = "New quote #{qid}: \"{quote}\"".format(qid=qid, quote=quote)
-	if name:
-		quote_msg += " —{name}".format(name=name)
-	if date:
-		quote_msg += " [{date!s}]".format(date=date)
-
-	conn.privmsg(respond_to, quote_msg)
+	conn.privmsg(respond_to, format_quote("New quote", qid, quote, name, date))
 
 @bot.command("modquote (\d+)(?: \((.+?)\))?(?: \[(.+?)\])? (.+)")
 @lrrbot.decorators.mod_only
@@ -133,12 +129,7 @@ def modquote(pg_conn, cur, lrrbot, conn, event, respond_to, qid, name, date, quo
 		WHERE qid = %s AND NOT deleted
 	""", (quote, name, date, qid))
 	if cur.rowcount == 1:
-		quote_msg = "Modified quote #{qid}: \"{quote}\"".format(qid=qid, quote=quote)
-		if name:
-			quote_msg += " —{name}".format(name=name)
-		if date:
-			quote_msg += " [{date!s}]".format(date=date)
-		conn.privmsg(respond_to, quote_msg)
+		conn.privmsg(respond_to, format_quote("Modified quote", qid, quote, name, date))
 	else:
 		conn.privmsg(respond_to, "Could not modify quote.")
 
@@ -186,9 +177,4 @@ def findquote(pg_conn, cur, lrrbot, conn, event, respond_to, query):
 	if row is None:
 		return conn.privmsg(respond_to, "Could not find any matching quotes.")
 	qid, quote, name, date = row
-	quote_msg = "Quote #{qid}: \"{quote}\"".format(qid=qid, quote=quote)
-	if name:
-		quote_msg += " —{name}".format(name=name)
-	if date:
-		quote_msg += " [{date!s}]".format(date=date)
-	conn.privmsg(respond_to, quote_msg)
+	conn.privmsg(respond_to, format_quote("Quote", qid, quote, name, date))

--- a/lrrbot/commands/quote.py
+++ b/lrrbot/commands/quote.py
@@ -22,9 +22,7 @@
 import common.postgres
 import common.time
 import lrrbot.decorators
-from common import utils
 from lrrbot.main import bot
-import datetime
 
 def format_quote(tag, qid, quote, name, date):
 	quote_msg = "{tag} #{qid}: \"{quote}\"".format(tag=tag, qid=qid, quote=quote)

--- a/lrrbot/commands/quote.py
+++ b/lrrbot/commands/quote.py
@@ -19,6 +19,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+import common.time
 import lrrbot.decorators
 from common import utils
 from lrrbot.main import bot
@@ -87,7 +88,7 @@ def addquote(pg_conn, cur, lrrbot, conn, event, respond_to, name, date, quote):
 	"""
 	if date:
 		try:
-			date = utils.strtodate(date)
+			date = common.time.strtodate(date)
 		except ValueError:
 			return conn.privmsg(respond_to, "Could not add quote due to invalid date.")
 
@@ -121,7 +122,7 @@ def modquote(pg_conn, cur, lrrbot, conn, event, respond_to, qid, name, date, quo
 	"""
 	if date:
 		try:
-			date = utils.strtodate(date)
+			date = common.time.strtodate(date)
 		except ValueError:
 			return conn.privmsg(respond_to, "Could not modify quote due to invalid date.")
 

--- a/lrrbot/commands/quote.py
+++ b/lrrbot/commands/quote.py
@@ -19,14 +19,14 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-
+import lrrbot.decorators
 from common import utils
 from lrrbot.main import bot
 import datetime
 
 @bot.command("quote(?: (?:(\d+)|(.+)))?")
-@utils.sub_only
-@utils.throttle(60, count=2)
+@lrrbot.decorators.sub_only
+@lrrbot.decorators.throttle(60, count=2)
 @utils.with_postgres
 def quote(pg_conn, cur, lrrbot, conn, event, respond_to, qid, attrib):
 	"""
@@ -73,7 +73,7 @@ def quote(pg_conn, cur, lrrbot, conn, event, respond_to, qid, attrib):
 	conn.privmsg(respond_to, quote_msg)
 
 @bot.command("addquote(?: \((.+?)\))?(?: \[(.+?)\])? (.+)")
-@utils.mod_only
+@lrrbot.decorators.mod_only
 @utils.with_postgres
 def addquote(pg_conn, cur, lrrbot, conn, event, respond_to, name, date, quote):
 	"""
@@ -107,7 +107,7 @@ def addquote(pg_conn, cur, lrrbot, conn, event, respond_to, name, date, quote):
 	conn.privmsg(respond_to, quote_msg)
 
 @bot.command("modquote (\d+)(?: \((.+?)\))?(?: \[(.+?)\])? (.+)")
-@utils.mod_only
+@lrrbot.decorators.mod_only
 @utils.with_postgres
 def modquote(pg_conn, cur, lrrbot, conn, event, respond_to, qid, name, date, quote):
 	"""
@@ -141,7 +141,7 @@ def modquote(pg_conn, cur, lrrbot, conn, event, respond_to, qid, name, date, quo
 		conn.privmsg(respond_to, "Could not modify quote.")
 
 @bot.command("delquote (\d+)")
-@utils.mod_only
+@lrrbot.decorators.mod_only
 @utils.with_postgres
 def delquote(pg_conn, cur, lrrbot, conn, event, respond_to, qid):
 	"""
@@ -163,8 +163,8 @@ def delquote(pg_conn, cur, lrrbot, conn, event, respond_to, qid):
 		conn.privmsg(respond_to, "Could not find quote #{qid}.".format(qid=qid))
 
 @bot.command("findquote (.*)")
-@utils.sub_only
-@utils.throttle(60, count=2)
+@lrrbot.decorators.sub_only
+@lrrbot.decorators.throttle(60, count=2)
 @utils.with_postgres
 def findquote(pg_conn, cur, lrrbot, conn, event, respond_to, query):
 	"""

--- a/lrrbot/commands/quote.py
+++ b/lrrbot/commands/quote.py
@@ -19,6 +19,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+import common.postgres
 import common.time
 import lrrbot.decorators
 from common import utils
@@ -28,7 +29,7 @@ import datetime
 @bot.command("quote(?: (?:(\d+)|(.+)))?")
 @lrrbot.decorators.sub_only
 @lrrbot.decorators.throttle(60, count=2)
-@utils.with_postgres
+@common.postgres.with_postgres
 def quote(pg_conn, cur, lrrbot, conn, event, respond_to, qid, attrib):
 	"""
 	Command: !quote
@@ -49,13 +50,13 @@ def quote(pg_conn, cur, lrrbot, conn, event, respond_to, qid, attrib):
 	elif attrib:
 		where, params = """
 			WHERE LOWER(attrib_name) LIKE %s AND NOT deleted
-		""", ("%" + utils.escape_like(attrib.lower()) + "%",)
+		""", ("%" + common.postgres.escape_like(attrib.lower()) + "%",)
 	else:
 		where, params = """
 			WHERE NOT deleted
 		""", ()
 
-	row = utils.pick_random_row(cur, """
+	row = common.postgres.pick_random_row(cur, """
 		SELECT qid, quote, attrib_name, attrib_date
 		FROM quotes
 		%s
@@ -75,7 +76,7 @@ def quote(pg_conn, cur, lrrbot, conn, event, respond_to, qid, attrib):
 
 @bot.command("addquote(?: \((.+?)\))?(?: \[(.+?)\])? (.+)")
 @lrrbot.decorators.mod_only
-@utils.with_postgres
+@common.postgres.with_postgres
 def addquote(pg_conn, cur, lrrbot, conn, event, respond_to, name, date, quote):
 	"""
 	Command: !addquote (NAME) [DATE] QUOTE
@@ -109,7 +110,7 @@ def addquote(pg_conn, cur, lrrbot, conn, event, respond_to, name, date, quote):
 
 @bot.command("modquote (\d+)(?: \((.+?)\))?(?: \[(.+?)\])? (.+)")
 @lrrbot.decorators.mod_only
-@utils.with_postgres
+@common.postgres.with_postgres
 def modquote(pg_conn, cur, lrrbot, conn, event, respond_to, qid, name, date, quote):
 	"""
 	Command: !modquote QID (NAME) [DATE] QUOTE
@@ -143,7 +144,7 @@ def modquote(pg_conn, cur, lrrbot, conn, event, respond_to, qid, name, date, quo
 
 @bot.command("delquote (\d+)")
 @lrrbot.decorators.mod_only
-@utils.with_postgres
+@common.postgres.with_postgres
 def delquote(pg_conn, cur, lrrbot, conn, event, respond_to, qid):
 	"""
 	Command: !delquote QID
@@ -166,7 +167,7 @@ def delquote(pg_conn, cur, lrrbot, conn, event, respond_to, qid):
 @bot.command("findquote (.*)")
 @lrrbot.decorators.sub_only
 @lrrbot.decorators.throttle(60, count=2)
-@utils.with_postgres
+@common.postgres.with_postgres
 def findquote(pg_conn, cur, lrrbot, conn, event, respond_to, query):
 	"""
 	Command: !findquote QUERY
@@ -175,7 +176,7 @@ def findquote(pg_conn, cur, lrrbot, conn, event, respond_to, query):
 	Search for a quote in the quote database.
 	"""
 
-	row = utils.pick_random_row(cur, """
+	row = common.postgres.pick_random_row(cur, """
 		SELECT qid, quote, attrib_name, attrib_date
 		FROM quotes
 		WHERE

--- a/lrrbot/commands/show.py
+++ b/lrrbot/commands/show.py
@@ -1,3 +1,4 @@
+import lrrbot.decorators
 from common import utils
 from lrrbot import storage
 from lrrbot.main import bot
@@ -12,7 +13,7 @@ def show_name(show):
 	return storage.data.get("shows", {}).get(show, {}).get("name", show)
 
 @bot.command("show")
-@utils.throttle()
+@lrrbot.decorators.throttle()
 def get_show(lrrbot, conn, event, respond_to):
 	"""
 	Command: !show
@@ -31,7 +32,7 @@ def print_show(lrrbot, conn, respond_to):
 		conn.privmsg(respond_to, "Current show not set.")
 
 @bot.command("show override (.*?)")
-@utils.mod_only
+@lrrbot.decorators.mod_only
 def show_override(lrrbot, conn, event, respond_to, show):
 	"""
 	Command: !show override ID

--- a/lrrbot/commands/show.py
+++ b/lrrbot/commands/show.py
@@ -1,13 +1,14 @@
 import lrrbot.decorators
 from common import utils
 from lrrbot import storage
+from lrrbot import twitch
 from lrrbot.main import bot
 
 
 def set_show(lrrbot, show):
 	if lrrbot.show != show.lower():
 		lrrbot.show = show.lower()
-		lrrbot.get_current_game_real.reset_throttle()
+		twitch.get_game.reset_throttle()
 
 def show_name(show):
 	return storage.data.get("shows", {}).get(show, {}).get("name", show)

--- a/lrrbot/commands/show.py
+++ b/lrrbot/commands/show.py
@@ -1,9 +1,7 @@
 import lrrbot.decorators
-from common import utils
 from lrrbot import storage
 from lrrbot import twitch
 from lrrbot.main import bot
-
 
 def set_show(lrrbot, show):
 	if lrrbot.show != show.lower():

--- a/lrrbot/commands/static.py
+++ b/lrrbot/commands/static.py
@@ -1,6 +1,7 @@
 import random
 import re
 
+import lrrbot.decorators
 from common import utils
 from common.config import config
 from lrrbot import storage
@@ -40,7 +41,7 @@ def generate_docstring():
 def generate_expression():
 	return "(%s)" % "|".join(re.escape(c).replace("\\ ", " ") for c in storage.data["responses"])
 
-@utils.throttle(30, params=[4], count=2)
+@lrrbot.decorators.throttle(30, params=[4], count=2)
 def static_response(lrrbot, conn, event, respond_to, command):
 	command = " ".join(command.split())
 	response_data = storage.data["responses"][command.lower()]

--- a/lrrbot/commands/static.py
+++ b/lrrbot/commands/static.py
@@ -2,11 +2,9 @@ import random
 import re
 
 import lrrbot.decorators
-from common import utils
 from common.config import config
 from lrrbot import storage
 from lrrbot.main import bot, log
-
 
 def generate_docstring():
 	inverse_responses = {}

--- a/lrrbot/commands/stats.py
+++ b/lrrbot/commands/stats.py
@@ -21,7 +21,7 @@ def stat_update(lrrbot, stat, n, set_=False):
 
 @bot.command("(%s)" % re_stats)
 @lrrbot.decorators.public_only
-@lrrbot.decorators.throttle(30, notify=utils.Visibility.PUBLIC, params=[4], modoverride=False, allowprivate=False)
+@lrrbot.decorators.throttle(30, notify=lrrbot.decorators.Visibility.PUBLIC, params=[4], modoverride=False, allowprivate=False)
 def increment(lrrbot, conn, event, respond_to, stat):
 	stat = stat.lower()
 	if stat == "completed":

--- a/lrrbot/commands/stats.py
+++ b/lrrbot/commands/stats.py
@@ -1,5 +1,4 @@
 import lrrbot.decorators
-from common import utils
 from lrrbot import storage
 from lrrbot.main import bot
 from lrrbot.commands.game import completed, game_name

--- a/lrrbot/commands/stats.py
+++ b/lrrbot/commands/stats.py
@@ -1,3 +1,4 @@
+import lrrbot.decorators
 from common import utils
 from lrrbot import storage
 from lrrbot.main import bot
@@ -19,8 +20,8 @@ def stat_update(lrrbot, stat, n, set_=False):
 	return game
 
 @bot.command("(%s)" % re_stats)
-@utils.public_only
-@utils.throttle(30, notify=utils.Visibility.PUBLIC, params=[4], modoverride=False, allowprivate=False)
+@lrrbot.decorators.public_only
+@lrrbot.decorators.throttle(30, notify=utils.Visibility.PUBLIC, params=[4], modoverride=False, allowprivate=False)
 def increment(lrrbot, conn, event, respond_to, stat):
 	stat = stat.lower()
 	if stat == "completed":
@@ -33,7 +34,7 @@ def increment(lrrbot, conn, event, respond_to, stat):
 	stat_print(lrrbot, conn, event, respond_to, stat, game, with_emote=True)
 
 @bot.command("(%s) add( \d+)?" % re_stats)
-@utils.mod_only
+@lrrbot.decorators.mod_only
 def add(lrrbot, conn, event, respond_to, stat, n):
 	stat = stat.lower()
 	n = 1 if n is None else int(n)
@@ -44,7 +45,7 @@ def add(lrrbot, conn, event, respond_to, stat, n):
 	stat_print(lrrbot, conn, event, respond_to, stat, game)
 
 @bot.command("(%s) remove( \d+)?" % re_stats)
-@utils.mod_only
+@lrrbot.decorators.mod_only
 def remove(lrrbot, conn, event, respond_to, stat, n):
 	stat = stat.lower()
 	n = 1 if n is None else int(n)
@@ -55,7 +56,7 @@ def remove(lrrbot, conn, event, respond_to, stat, n):
 	stat_print(lrrbot, conn, event, respond_to, stat, game)
 
 @bot.command("(%s) set (\d+)" % re_stats)
-@utils.mod_only
+@lrrbot.decorators.mod_only
 def stat_set(lrrbot, conn, event, respond_to, stat, n):
 	stat = stat.lower()
 	n = 1 if n is None else int(n)
@@ -66,7 +67,7 @@ def stat_set(lrrbot, conn, event, respond_to, stat, n):
 	stat_print(lrrbot, conn, event, respond_to, stat, game)
 
 @bot.command("(%s)count" % re_stats)
-@utils.throttle(params=[4])
+@lrrbot.decorators.throttle(params=[4])
 def get_stat(lrrbot, conn, event, respond_to, stat):
 	stat_print(lrrbot, conn, event, respond_to, stat)
 
@@ -88,7 +89,7 @@ def stat_print(lrrbot, conn, event, respond_to, stat, game=None, with_emote=Fals
 	conn.privmsg(respond_to, "%s%d %s for %s on %s" % (emote, count, display, game_name(game), show_name(show)))
 
 @bot.command("total(%s)s?" % re_stats)
-@utils.throttle(params=[4])
+@lrrbot.decorators.throttle(params=[4])
 def printtotal(lrrbot, conn, event, respond_to, stat):
 	stat = stat.lower()
 	count = 0

--- a/lrrbot/commands/strawpoll.py
+++ b/lrrbot/commands/strawpoll.py
@@ -2,6 +2,7 @@ import time
 import json
 import random
 
+import common.http
 import lrrbot.decorators
 from common import utils
 from lrrbot.main import bot
@@ -17,7 +18,7 @@ def check_polls(lrrbot, conn):
 	for end, title, poll_id, respond_to in lrrbot.polls:
 		if end < now:
 			url = "https://strawpoll.me/api/v2/polls/%s" % poll_id
-			data = json.loads(utils.http_request(url))
+			data = json.loads(common.http.http_request(url))
 			options = sorted(zip(data["options"], data["votes"]), key=lambda e: (e[1], random.random()), reverse=True)
 			options = "; ".join(map(strawpoll_format, enumerate(options)))
 			response = "Poll complete: %s: %s" % (data["title"], options)
@@ -56,7 +57,7 @@ def new_poll(lrrbot, conn, event, respond_to, multi, timeout, poll_id, title, op
 	"""
 	if poll_id is not None:
 		url = "https://strawpoll.me/api/v2/polls/%s" % poll_id
-		data = json.loads(utils.http_request(url))
+		data = json.loads(common.http.http_request(url))
 		title = data["title"]
 	else:
 		if title is None:
@@ -68,7 +69,7 @@ def new_poll(lrrbot, conn, event, respond_to, multi, timeout, poll_id, title, op
 		else:
 			options = options.split()
 		data = json.dumps({"options": options, "title": title, "multi": multi is not None})
-		response = utils.http_request("https://strawpoll.me/api/v2/polls", data, "POST", headers = {"Content-Type": "application/json"})
+		response = common.http.http_request("https://strawpoll.me/api/v2/polls", data, "POST", headers = {"Content-Type": "application/json"})
 		poll_id = json.loads(response)["id"]
 	if timeout is not None:
 		timeout = int(timeout)

--- a/lrrbot/commands/strawpoll.py
+++ b/lrrbot/commands/strawpoll.py
@@ -2,6 +2,7 @@ import time
 import json
 import random
 
+import lrrbot.decorators
 from common import utils
 from lrrbot.main import bot
 
@@ -25,7 +26,7 @@ def check_polls(lrrbot, conn):
 	lrrbot.polls = list(filter(lambda e: e[0] >= now, lrrbot.polls))
 
 @bot.command("polls")
-@utils.throttle()
+@lrrbot.decorators.throttle()
 def polls(lrrbot, conn, event, respond_to):
 	"""
 	Command: !polls
@@ -42,7 +43,7 @@ def polls(lrrbot, conn, event, respond_to):
 	conn.privmsg(respond_to, utils.shorten("Active polls: "+"; ".join(messages), 450))
 
 @bot.command("(multi)?poll (?:(\d+) )?(?:(?:https?://)?(?:www\.)?strawpoll\.me/([^/]+)(?:/r?)?|(?:([^:]+) ?: ?)?(.*))")
-@utils.mod_only
+@lrrbot.decorators.mod_only
 def new_poll(lrrbot, conn, event, respond_to, multi, timeout, poll_id, title, options):
 	"""
 	Command: !poll N https://strawpoll.me/ID
@@ -78,7 +79,7 @@ def new_poll(lrrbot, conn, event, respond_to, multi, timeout, poll_id, title, op
 	conn.privmsg(respond_to, "New poll: %s (https://strawpoll.me/%s): %s from now" % (title, poll_id, utils.nice_duration(timeout, 1)))
 
 @bot.command("pollsclear")
-@utils.mod_only
+@lrrbot.decorators.mod_only
 def clear_polls(lrrbot, conn, event, respond_to):
 	"""
 	Command: !pollsclear

--- a/lrrbot/commands/strawpoll.py
+++ b/lrrbot/commands/strawpoll.py
@@ -3,6 +3,7 @@ import json
 import random
 
 import common.http
+import common.time
 import lrrbot.decorators
 from common import utils
 from lrrbot.main import bot
@@ -40,7 +41,7 @@ def polls(lrrbot, conn, event, respond_to):
 	now = time.time()
 	messages = []
 	for end, title, poll_id, respond_to in lrrbot.polls:
-		messages += ["%s (https://strawpoll.me/%s): %s from now" % (title, poll_id, utils.nice_duration(end - now, 1))]
+		messages += ["%s (https://strawpoll.me/%s): %s from now" % (title, poll_id, common.time.nice_duration(end - now, 1))]
 	conn.privmsg(respond_to, utils.shorten("Active polls: "+"; ".join(messages), 450))
 
 @bot.command("(multi)?poll (?:(\d+) )?(?:(?:https?://)?(?:www\.)?strawpoll\.me/([^/]+)(?:/r?)?|(?:([^:]+) ?: ?)?(.*))")
@@ -77,7 +78,7 @@ def new_poll(lrrbot, conn, event, respond_to, multi, timeout, poll_id, title, op
 		timeout = DEFAULT_TIMEOUT
 	end = time.time() + int(timeout)
 	lrrbot.polls += [(end, title, poll_id, respond_to)]
-	conn.privmsg(respond_to, "New poll: %s (https://strawpoll.me/%s): %s from now" % (title, poll_id, utils.nice_duration(timeout, 1)))
+	conn.privmsg(respond_to, "New poll: %s (https://strawpoll.me/%s): %s from now" % (title, poll_id, common.time.nice_duration(timeout, 1)))
 
 @bot.command("pollsclear")
 @lrrbot.decorators.mod_only

--- a/lrrbot/commands/strawpoll.py
+++ b/lrrbot/commands/strawpoll.py
@@ -19,7 +19,7 @@ def check_polls(lrrbot, conn):
 	for end, title, poll_id, respond_to in lrrbot.polls:
 		if end < now:
 			url = "https://strawpoll.me/api/v2/polls/%s" % poll_id
-			data = json.loads(common.http.http_request(url))
+			data = json.loads(common.http.request(url))
 			options = sorted(zip(data["options"], data["votes"]), key=lambda e: (e[1], random.random()), reverse=True)
 			options = "; ".join(map(strawpoll_format, enumerate(options)))
 			response = "Poll complete: %s: %s" % (data["title"], options)
@@ -58,7 +58,7 @@ def new_poll(lrrbot, conn, event, respond_to, multi, timeout, poll_id, title, op
 	"""
 	if poll_id is not None:
 		url = "https://strawpoll.me/api/v2/polls/%s" % poll_id
-		data = json.loads(common.http.http_request(url))
+		data = json.loads(common.http.request(url))
 		title = data["title"]
 	else:
 		if title is None:
@@ -70,7 +70,7 @@ def new_poll(lrrbot, conn, event, respond_to, multi, timeout, poll_id, title, op
 		else:
 			options = options.split()
 		data = json.dumps({"options": options, "title": title, "multi": multi is not None})
-		response = common.http.http_request("https://strawpoll.me/api/v2/polls", data, "POST", headers = {"Content-Type": "application/json"})
+		response = common.http.request("https://strawpoll.me/api/v2/polls", data, "POST", headers = {"Content-Type": "application/json"})
 		poll_id = json.loads(response)["id"]
 	if timeout is not None:
 		timeout = int(timeout)

--- a/lrrbot/decorators.py
+++ b/lrrbot/decorators.py
@@ -20,7 +20,6 @@ def mod_only(func):
 	def on_event(self, conn, event, ...):
 		...
 	"""
-
 	# Only complain about non-mods with throttle
 	# but allow the command itself to be run without throttling
 	@throttle(notify=Visibility.SILENT, modoverride=False)
@@ -45,7 +44,6 @@ def mod_only(func):
 		"Mod-Only", "true"))
 	return wrapper
 
-
 @coro_decorator
 def sub_only(func):
 	"""Prevent an event-handler function from being called by non-subscribers
@@ -55,7 +53,6 @@ def sub_only(func):
 	def on_event(self, conn, event, ...):
 		...
 	"""
-
 	@throttle(notify=Visibility.SILENT, modoverride=False)
 	def sub_complaint(self, conn, event):
 		source = irc.client.NickMask(event.source)
@@ -78,7 +75,6 @@ def sub_only(func):
 		"Sub-Only", "true"))
 	return wrapper
 
-
 @coro_decorator
 def public_only(func):
 	"""Prevent an event-handler function from being called via private message
@@ -100,7 +96,6 @@ def public_only(func):
 		"Public-Only", "true"))
 	return wrapper
 
-
 class twitch_throttle:
 	def __init__(self, count=20, period=30):
 		self.count = count
@@ -120,12 +115,10 @@ class twitch_throttle:
 		wrapper.is_throttled = True
 		return wrapper
 
-
 class Visibility(enum.Enum):
 	SILENT = 0
 	PRIVATE = 1
 	PUBLIC = 2
-
 
 class throttle(throttle_base):
 	"""Prevent an event function from being called more often than once per period

--- a/lrrbot/decorators.py
+++ b/lrrbot/decorators.py
@@ -1,0 +1,135 @@
+import asyncio
+import functools
+import logging
+import time
+
+import irc.client
+
+from common.utils import coro_decorator, Visibility, throttle_base, DEFAULT_THROTTLE
+from lrrbot.docstring import encode_docstring, add_header, parse_docstring
+
+log = logging.getLogger("lrrbot.decorators")
+
+@coro_decorator
+def mod_only(func):
+	"""Prevent an event-handler function from being called by non-moderators
+
+	Usage:
+	@mod_only
+	def on_event(self, conn, event, ...):
+		...
+	"""
+
+	# Only complain about non-mods with throttle
+	# but allow the command itself to be run without throttling
+	@throttle(notify=Visibility.SILENT, modoverride=False)
+	def mod_complaint(self, conn, event):
+		source = irc.client.NickMask(event.source)
+		if irc.client.is_channel(event.target):
+			respond_to = event.target
+		else:
+			respond_to = source.nick
+		conn.privmsg(respond_to, "%s: That is a mod-only command" % source.nick)
+
+	@functools.wraps(func)
+	@asyncio.coroutine
+	def wrapper(self, conn, event, *args, **kwargs):
+		if self.is_mod(event):
+			return (yield from func(self, conn, event, *args, **kwargs))
+		else:
+			log.info("Refusing %s due to not-a-mod" % func.__name__)
+			mod_complaint(self, conn, event)
+			return None
+	wrapper.__doc__ = encode_docstring(add_header(parse_docstring(wrapper.__doc__),
+		"Mod-Only", "true"))
+	return wrapper
+
+
+@coro_decorator
+def sub_only(func):
+	"""Prevent an event-handler function from being called by non-subscribers
+
+	Usage:
+	@sub_only
+	def on_event(self, conn, event, ...):
+		...
+	"""
+
+	@throttle(notify=Visibility.SILENT, modoverride=False)
+	def sub_complaint(self, conn, event):
+		source = irc.client.NickMask(event.source)
+		if irc.client.is_channel(event.target):
+			respond_to = event.target
+		else:
+			respond_to = source.nick
+		conn.privmsg(respond_to, "%s: That is a subscriber-only command" % source.nick)
+
+	@functools.wraps(func)
+	@asyncio.coroutine
+	def wrapper(self, conn, event, *args, **kwargs):
+		if self.is_sub(event) or self.is_mod(event):
+			return (yield from func(self, conn, event, *args, **kwargs))
+		else:
+			log.info("Refusing %s due to not-a-sub" % func.__name__)
+			sub_complaint(self, conn, event)
+			return None
+	wrapper.__doc__ = encode_docstring(add_header(parse_docstring(wrapper.__doc__),
+		"Sub-Only", "true"))
+	return wrapper
+
+
+@coro_decorator
+def public_only(func):
+	"""Prevent an event-handler function from being called via private message
+
+	Usage:
+	@public_only
+	def on_event(self, conn, event, ...):
+		...
+	"""
+	@functools.wraps(func)
+	@asyncio.coroutine
+	def wrapper(self, conn, event, *args, **kwargs):
+		if event.type == "pubmsg" or self.is_mod(event):
+			return (yield from func(self, conn, event, *args, **kwargs))
+		else:
+			source = irc.client.NickMask(event.source)
+			conn.privmsg(source.nick, "That command cannot be used via private message")
+	wrapper.__doc__ = encode_docstring(add_header(parse_docstring(wrapper.__doc__),
+		"Public-Only", "true"))
+	return wrapper
+
+
+class twitch_throttle:
+	def __init__(self, count=20, period=30):
+		self.count = count
+		self.period = period
+		self.timestamps = []
+
+	def __call__(self, f):
+		@functools.wraps(f, assigned=functools.WRAPPER_ASSIGNMENTS + ("is_logged",))
+		def wrapper(*args, **kwargs):
+			now = time.time()
+			self.timestamps = [t for t in self.timestamps if now-t <= self.period]
+			if len(self.timestamps) >= self.count:
+				log.info("Ignoring {}(*{}, **{})".format(f.__name__, args, kwargs))
+			else:
+				self.timestamps.append(now)
+				return f(*args, **kwargs)
+		wrapper.is_throttled = True
+		return wrapper
+
+
+class throttle(throttle_base):
+	"""Prevent an event function from being called more often than once per period
+
+	Usage:
+	@throttle([period])
+	def func(lrrbot, conn, event, ...):
+		...
+
+	count allows the function to be called a given number of times during the period,
+	but no more.
+	"""
+	def __init__(self, period=DEFAULT_THROTTLE, notify=Visibility.PRIVATE, modoverride=True, params=[], log=True, count=1, allowprivate=True):
+		super().__init__(period=period, notify=notify, modoverride=modoverride, params=params, log=log, count=count, allowprivate=allowprivate)

--- a/lrrbot/docstring.py
+++ b/lrrbot/docstring.py
@@ -7,20 +7,17 @@ DOCSTRING_IMPLICIT_PREFIX = """Content-Type: multipart/message; boundary=command
 --command"""
 DOCSTRING_IMPLICIT_SUFFIX = "\n--command--"
 
-
 def parse_docstring(docstring):
 	if docstring is None:
 		docstring = ""
 	docstring = DOCSTRING_IMPLICIT_PREFIX + docstring + DOCSTRING_IMPLICIT_SUFFIX
 	return email.parser.Parser().parsestr(deindent(docstring))
 
-
 def encode_docstring(docstring):
 	docstring = str(docstring).rstrip()
 	assert docstring.startswith(DOCSTRING_IMPLICIT_PREFIX)
 	assert docstring.endswith(DOCSTRING_IMPLICIT_SUFFIX)
 	return docstring[len(DOCSTRING_IMPLICIT_PREFIX):-len(DOCSTRING_IMPLICIT_SUFFIX)]
-
 
 def add_header(doc, name, value):
 	for part in doc.walk():

--- a/lrrbot/docstring.py
+++ b/lrrbot/docstring.py
@@ -1,0 +1,29 @@
+import email.parser
+
+from common.utils import deindent
+
+DOCSTRING_IMPLICIT_PREFIX = """Content-Type: multipart/message; boundary=command
+
+--command"""
+DOCSTRING_IMPLICIT_SUFFIX = "\n--command--"
+
+
+def parse_docstring(docstring):
+	if docstring is None:
+		docstring = ""
+	docstring = DOCSTRING_IMPLICIT_PREFIX + docstring + DOCSTRING_IMPLICIT_SUFFIX
+	return email.parser.Parser().parsestr(deindent(docstring))
+
+
+def encode_docstring(docstring):
+	docstring = str(docstring).rstrip()
+	assert docstring.startswith(DOCSTRING_IMPLICIT_PREFIX)
+	assert docstring.endswith(DOCSTRING_IMPLICIT_SUFFIX)
+	return docstring[len(DOCSTRING_IMPLICIT_PREFIX):-len(DOCSTRING_IMPLICIT_SUFFIX)]
+
+
+def add_header(doc, name, value):
+	for part in doc.walk():
+		if part.get_content_maintype() != "multipart":
+			part[name] = value
+	return doc

--- a/lrrbot/googlecalendar.py
+++ b/lrrbot/googlecalendar.py
@@ -7,6 +7,7 @@ import pytz
 import pytz.exceptions
 
 import common.http
+import common.time
 from common import utils
 from common.config import config
 
@@ -120,7 +121,7 @@ def get_next_event_text(calendar, after=None, include_current=None, tz=None, ver
 	elif isinstance(tz, str):
 		tz = tz.strip()
 		try:
-			tz = utils.get_timezone(tz)
+			tz = common.time.get_timezone(tz)
 		except pytz.exceptions.UnknownTimeZoneError:
 			return "Unknown timezone: %s" % tz
 
@@ -138,9 +139,9 @@ def get_next_event_text(calendar, after=None, include_current=None, tz=None, ver
 		if i == len(events) - 1 or ev['start'] != events[i+1]['start']:
 			if verbose:
 				if ev['start'] < after:
-					nice_duration = utils.nice_duration(after - ev['start'], 1) + " ago"
+					nice_duration = common.time.nice_duration(after - ev['start'], 1) + " ago"
 				else:
-					nice_duration = utils.nice_duration(ev['start'] - after, 1) + " from now"
+					nice_duration = common.time.nice_duration(ev['start'] - after, 1) + " from now"
 				strs.append("%s at %s (%s)" % (title, ev['start'].astimezone(tz).strftime(DISPLAY_FORMAT), nice_duration))
 			else:
 				strs.append("%s at %s" % (ev['title'], ev['start'].astimezone(tz).strftime(DISPLAY_FORMAT)))

--- a/lrrbot/googlecalendar.py
+++ b/lrrbot/googlecalendar.py
@@ -11,7 +11,6 @@ import common.time
 from common import utils
 from common.config import config
 
-
 CACHE_EXPIRY = 15*60
 CALENDAR_LRL = "loadingreadyrun.com_72jmf1fn564cbbr84l048pv1go@group.calendar.google.com"
 CALENDAR_FAN = "caffeinatedlemur@gmail.com"
@@ -156,4 +155,3 @@ def get_next_event_text(calendar, after=None, include_current=None, tz=None, ver
 			response = "Next scheduled fan stream: %s." % response
 
 	return utils.shorten(response, 450) # For safety
-

--- a/lrrbot/googlecalendar.py
+++ b/lrrbot/googlecalendar.py
@@ -6,6 +6,7 @@ import dateutil.parser
 import pytz
 import pytz.exceptions
 
+import common.http
 from common import utils
 from common.config import config
 
@@ -47,7 +48,7 @@ def get_upcoming_events(calendar, after=None):
 		"timeZone": config['timezone'].zone,
 		"key": config['google_key'],
 	}
-	res = utils.http_request(url, data)
+	res = common.http.http_request(url, data)
 	res = json.loads(res)
 	if 'error' in res:
 		raise Exception(res['error']['message'])

--- a/lrrbot/googlecalendar.py
+++ b/lrrbot/googlecalendar.py
@@ -49,7 +49,7 @@ def get_upcoming_events(calendar, after=None):
 		"timeZone": config['timezone'].zone,
 		"key": config['google_key'],
 	}
-	res = common.http.http_request(url, data)
+	res = common.http.request(url, data)
 	res = json.loads(res)
 	if 'error' in res:
 		raise Exception(res['error']['message'])

--- a/lrrbot/linkspam.py
+++ b/lrrbot/linkspam.py
@@ -3,7 +3,6 @@ import re
 import logging
 
 import common.url
-from common import utils
 from lrrbot import storage
 import irc.client
 

--- a/lrrbot/linkspam.py
+++ b/lrrbot/linkspam.py
@@ -1,6 +1,8 @@
 import asyncio
 import re
 import logging
+
+import common.url
 from common import utils
 from lrrbot import storage
 import irc.client
@@ -10,7 +12,7 @@ log = logging.getLogger('linkspam')
 class LinkSpam:
 	def __init__(self, loop):
 		self._loop = loop
-		self._re_url = loop.run_until_complete(utils.url_regex())
+		self._re_url = loop.run_until_complete(common.url.url_regex())
 		self._rules = [
 			{
 				"re": re.compile(rule["re"], re.IGNORECASE),
@@ -39,7 +41,7 @@ class LinkSpam:
 				if url is not None:
 					urls.append(url)
 					break
-		canonical_urls = yield from asyncio.gather(*map(utils.canonical_url, urls), loop=self._loop)
+		canonical_urls = yield from asyncio.gather(*map(common.url.canonical_url, urls), loop=self._loop)
 		for original_url, url_chain in zip(urls, canonical_urls):
 			for url in url_chain:
 				for rule in self._rules:

--- a/lrrbot/main.py
+++ b/lrrbot/main.py
@@ -18,6 +18,7 @@ import irc.bot
 import irc.client
 import irc.modes
 
+import common.http
 import lrrbot.decorators
 from common import utils
 from common.config import config
@@ -299,7 +300,7 @@ class LRRBot(irc.bot.SingleServerIRCBot, linkspam.LinkSpam):
 		}
 		if irc.client.is_channel(event.target):
 			notifyparams['channel'] = event.target[1:]
-		utils.api_request('notifications/newmessage', notifyparams, 'POST')
+		common.http.api_request('notifications/newmessage', notifyparams, 'POST')
 
 	def on_subscriber(self, conn, channel, user, eventtime, logo=None, monthcount=None):
 		notifyparams = {
@@ -336,7 +337,7 @@ class LRRBot(irc.bot.SingleServerIRCBot, linkspam.LinkSpam):
 		self.lastsubs = self.lastsubs[-10:]
 		storage.save()
 		conn.privmsg(channel, "lrrSPOT Thanks for subscribing, %s! (Today's storm count: %d)" % (notifyparams['subuser'], storage.data["storm"]["count"]))
-		utils.api_request('notifications/newmessage', notifyparams, 'POST')
+		common.http.api_request('notifications/newmessage', notifyparams, 'POST')
 
 		self.subs.add(user.lower())
 		storage.data['subs'] = list(self.subs)

--- a/lrrbot/main.py
+++ b/lrrbot/main.py
@@ -6,14 +6,10 @@ import time
 import datetime
 import json
 import logging
-import socket
-import select
 import functools
-import queue
 import asyncio
 import traceback
 
-import dateutil.parser
 import irc.bot
 import irc.client
 import irc.modes
@@ -23,7 +19,6 @@ import lrrbot.decorators
 from common import utils
 from common.config import config
 from lrrbot import chatlog, storage, twitch, twitchsubs, whisper, asyncreactor, linkspam
-
 
 log = logging.getLogger('lrrbot')
 

--- a/lrrbot/main.py
+++ b/lrrbot/main.py
@@ -18,6 +18,7 @@ import irc.bot
 import irc.client
 import irc.modes
 
+import lrrbot.decorators
 from common import utils
 from common.config import config
 from lrrbot import chatlog, storage, twitch, twitchsubs, whisper, asyncreactor, linkspam
@@ -480,7 +481,7 @@ class LRRBot(irc.bot.SingleServerIRCBot, linkspam.LinkSpam):
 		"""
 		if hasattr(conn.privmsg, "is_wrapped"):
 			return
-		original_privmsg = utils.twitch_throttle()(conn.privmsg)
+		original_privmsg = lrrbot.decorators.twitch_throttle()(conn.privmsg)
 		@functools.wraps(original_privmsg)
 		def new_privmsg(target, text):
 			if irc.client.is_channel(target):

--- a/lrrbot/serverevents.py
+++ b/lrrbot/serverevents.py
@@ -4,12 +4,10 @@ import math
 import logging
 
 import common.postgres
-import lrrbot.docstring
 from common import utils
 from common.config import config
 from lrrbot import googlecalendar, storage, commands, twitch
 from lrrbot.main import bot
-
 
 log = logging.getLogger('serverevents')
 

--- a/lrrbot/serverevents.py
+++ b/lrrbot/serverevents.py
@@ -4,6 +4,7 @@ import math
 import logging
 
 import common.postgres
+import common.utils
 from common import utils
 from common.config import config
 from lrrbot import googlecalendar, storage, commands, twitch
@@ -168,11 +169,12 @@ def get_tweet(conn, cur, lrrbot, user, data):
 		if mode == 0: # get random !advice
 			return random.choice(storage.data['responses']['advice']['response'])
 		elif mode == 1: # get a random !quote
-			row = common.postgres.pick_random_row(cur, """
+			cur.execute("""
 				SELECT qid, quote, attrib_name, attrib_date
 				FROM quotes
 				WHERE NOT deleted
 			""")
+			row = common.utils.pick_random_elements(cur, 1)[0]
 			if row is None:
 				return None
 

--- a/lrrbot/serverevents.py
+++ b/lrrbot/serverevents.py
@@ -3,6 +3,7 @@ import re
 import math
 import logging
 
+import lrrbot.docstring
 from common import utils
 from common.config import config
 from lrrbot import googlecalendar, storage, commands, twitch
@@ -75,7 +76,7 @@ def modify_spam_rules(lrrbot, user, data):
 def get_commands(lrrbot, user, data):
 	ret = []
 	for command in lrrbot.commands.values():
-		doc = utils.parse_docstring(command['func'].__doc__)
+		doc = lrrbot.docstring.parse_docstring(command['func'].__doc__)
 		for cmd in doc.walk():
 			if cmd.get_content_maintype() == "multipart":
 				continue

--- a/lrrbot/serverevents.py
+++ b/lrrbot/serverevents.py
@@ -3,6 +3,7 @@ import re
 import math
 import logging
 
+import common.postgres
 import lrrbot.docstring
 from common import utils
 from common.config import config
@@ -162,14 +163,14 @@ def get_show(lrrbot, user, data):
 	return lrrbot.show_override or lrrbot.show
 
 @bot.server_event()
-@utils.with_postgres
+@common.postgres.with_postgres
 def get_tweet(conn, cur, lrrbot, user, data):
 	if user is not None and lrrbot.is_mod_nick(user):
 		mode = utils.weighted_choice([(0, 10), (1, 4), (2, 1)])
 		if mode == 0: # get random !advice
 			return random.choice(storage.data['responses']['advice']['response'])
 		elif mode == 1: # get a random !quote
-			row = utils.pick_random_row(cur, """
+			row = common.postgres.pick_random_row(cur, """
 				SELECT qid, quote, attrib_name, attrib_date
 				FROM quotes
 				WHERE NOT deleted

--- a/lrrbot/storage.py
+++ b/lrrbot/storage.py
@@ -4,7 +4,6 @@ import os
 from common import utils
 from common.config import config
 
-
 """
 Data structure:
 

--- a/lrrbot/twitch.py
+++ b/lrrbot/twitch.py
@@ -2,6 +2,7 @@ import json
 import random
 import asyncio
 
+import common.http
 from common import utils
 from common.config import config
 from lrrbot import storage
@@ -26,7 +27,7 @@ def get_info_uncached(username=None, use_fallback=True):
 
 	# Attempt to get the channel data from /streams/channelname
 	# If this succeeds, it means the channel is currently live
-	res = utils.http_request("https://api.twitch.tv/kraken/streams/%s" % username)
+	res = common.http.http_request("https://api.twitch.tv/kraken/streams/%s" % username)
 	data = json.loads(res)
 	channel_data = data.get('stream') and data['stream'].get('channel')
 	if channel_data:
@@ -40,7 +41,7 @@ def get_info_uncached(username=None, use_fallback=True):
 
 	# If that failed, it means the channel is offline
 	# Ge the channel data from here instead
-	res = utils.http_request("https://api.twitch.tv/kraken/channels/%s" % username)
+	res = common.http.http_request("https://api.twitch.tv/kraken/channels/%s" % username)
 	channel_data = json.loads(res)
 	channel_data['live'] = False
 	return channel_data
@@ -64,7 +65,7 @@ def get_game(name, all=False):
 		'type': 'suggest',
 		'live': 'false',
 	}
-	res = utils.http_request("https://api.twitch.tv/kraken/search/games", search_opts)
+	res = common.http.http_request("https://api.twitch.tv/kraken/search/games", search_opts)
 	res = json.loads(res)
 	if all:
 		return res['games']
@@ -107,7 +108,7 @@ def get_subscribers(channel=None, count=5, offset=None, latest=True):
 	}
 	if offset is not None:
 		data['offset'] = offset
-	res = yield from utils.http_request_coro("https://api.twitch.tv/kraken/channels/%s/subscriptions" % channel, headers=headers, data=data)
+	res = yield from common.http.http_request_coro("https://api.twitch.tv/kraken/channels/%s/subscriptions" % channel, headers=headers, data=data)
 	subscriber_data = json.loads(res)
 	return [
 		(sub['user']['display_name'], sub['user'].get('logo'), sub['created_at'])
@@ -118,7 +119,7 @@ def get_group_servers():
 	"""
 	Get the secondary Twitch chat servers
 	"""
-	res = utils.http_request("https://chatdepot.twitch.tv/room_memberships", {'oauth_token': storage.data['twitch_oauth'][config['username']]}, maxtries=1)
+	res = common.http.http_request("https://chatdepot.twitch.tv/room_memberships", {'oauth_token': storage.data['twitch_oauth'][config['username']]}, maxtries=1)
 	res = json.loads(res)
 	def parse_server(s):
 		if ':' in s:
@@ -150,7 +151,7 @@ def get_follows_channels(username=None):
 	follows = []
 	total = 1
 	while len(follows) < total:
-		data = yield from utils.http_request_coro(url)
+		data = yield from common.http.http_request_coro(url)
 		data = json.loads(data)
 		total = data["_total"]
 		follows += data["follows"]
@@ -168,7 +169,7 @@ def get_streams_followed(username=None):
 	streams = []
 	total = 1
 	while len(streams) < total:
-		data = yield from utils.http_request_coro(url, headers=headers)
+		data = yield from common.http.http_request_coro(url, headers=headers)
 		data = json.loads(data)
 		total = data["_total"]
 		streams += data["streams"]
@@ -182,8 +183,8 @@ def follow_channel(target, user=None):
 	headers = {
 		"Authorization": "OAuth %s" % storage.data['twitch_oauth'][user],
 	}
-	yield from utils.http_request_coro("https://api.twitch.tv/kraken/users/%s/follows/channels/%s" % (user, target),
-									data={"notifications": "false"}, method="PUT", headers=headers)
+	yield from common.http.http_request_coro("https://api.twitch.tv/kraken/users/%s/follows/channels/%s" % (user, target),
+											 data={"notifications": "false"}, method="PUT", headers=headers)
 
 @asyncio.coroutine
 def unfollow_channel(target, user=None):
@@ -192,13 +193,13 @@ def unfollow_channel(target, user=None):
 	headers = {
 		"Authorization": "OAuth %s" % storage.data['twitch_oauth'][user],
 	}
-	yield from utils.http_request_coro("https://api.twitch.tv/kraken/users/%s/follows/channels/%s" % (user, target),
-									method="DELETE", headers=headers)
+	yield from common.http.http_request_coro("https://api.twitch.tv/kraken/users/%s/follows/channels/%s" % (user, target),
+											 method="DELETE", headers=headers)
 
 @asyncio.coroutine
 def get_videos(channel=None, offset=0, limit=10, broadcasts=False, hls=False):
 	channel = channel or config["channel"]
-	data = yield from utils.http_request_coro("https://api.twitch.tv/kraken/channels/%s/videos" % channel, data={
+	data = yield from common.http.http_request_coro("https://api.twitch.tv/kraken/channels/%s/videos" % channel, data={
 		"offset": offset,
 		"limit": limit,
 		"broadcasts": "true" if broadcasts else "false",

--- a/lrrbot/twitch.py
+++ b/lrrbot/twitch.py
@@ -7,9 +7,7 @@ from common import utils
 from common.config import config
 from lrrbot import storage
 
-
 GAME_CHECK_INTERVAL = 5*60
-
 
 def get_info_uncached(username=None, use_fallback=True):
 	"""

--- a/lrrbot/twitch.py
+++ b/lrrbot/twitch.py
@@ -27,7 +27,7 @@ def get_info_uncached(username=None, use_fallback=True):
 
 	# Attempt to get the channel data from /streams/channelname
 	# If this succeeds, it means the channel is currently live
-	res = common.http.http_request("https://api.twitch.tv/kraken/streams/%s" % username)
+	res = common.http.request("https://api.twitch.tv/kraken/streams/%s" % username)
 	data = json.loads(res)
 	channel_data = data.get('stream') and data['stream'].get('channel')
 	if channel_data:
@@ -41,7 +41,7 @@ def get_info_uncached(username=None, use_fallback=True):
 
 	# If that failed, it means the channel is offline
 	# Ge the channel data from here instead
-	res = common.http.http_request("https://api.twitch.tv/kraken/channels/%s" % username)
+	res = common.http.request("https://api.twitch.tv/kraken/channels/%s" % username)
 	channel_data = json.loads(res)
 	channel_data['live'] = False
 	return channel_data
@@ -65,7 +65,7 @@ def get_game(name, all=False):
 		'type': 'suggest',
 		'live': 'false',
 	}
-	res = common.http.http_request("https://api.twitch.tv/kraken/search/games", search_opts)
+	res = common.http.request("https://api.twitch.tv/kraken/search/games", search_opts)
 	res = json.loads(res)
 	if all:
 		return res['games']
@@ -108,7 +108,7 @@ def get_subscribers(channel=None, count=5, offset=None, latest=True):
 	}
 	if offset is not None:
 		data['offset'] = offset
-	res = yield from common.http.http_request_coro("https://api.twitch.tv/kraken/channels/%s/subscriptions" % channel, headers=headers, data=data)
+	res = yield from common.http.request_coro("https://api.twitch.tv/kraken/channels/%s/subscriptions" % channel, headers=headers, data=data)
 	subscriber_data = json.loads(res)
 	return [
 		(sub['user']['display_name'], sub['user'].get('logo'), sub['created_at'])
@@ -119,7 +119,7 @@ def get_group_servers():
 	"""
 	Get the secondary Twitch chat servers
 	"""
-	res = common.http.http_request("https://chatdepot.twitch.tv/room_memberships", {'oauth_token': storage.data['twitch_oauth'][config['username']]}, maxtries=1)
+	res = common.http.request("https://chatdepot.twitch.tv/room_memberships", {'oauth_token': storage.data['twitch_oauth'][config['username']]}, maxtries=1)
 	res = json.loads(res)
 	def parse_server(s):
 		if ':' in s:
@@ -151,7 +151,7 @@ def get_follows_channels(username=None):
 	follows = []
 	total = 1
 	while len(follows) < total:
-		data = yield from common.http.http_request_coro(url)
+		data = yield from common.http.request_coro(url)
 		data = json.loads(data)
 		total = data["_total"]
 		follows += data["follows"]
@@ -169,7 +169,7 @@ def get_streams_followed(username=None):
 	streams = []
 	total = 1
 	while len(streams) < total:
-		data = yield from common.http.http_request_coro(url, headers=headers)
+		data = yield from common.http.request_coro(url, headers=headers)
 		data = json.loads(data)
 		total = data["_total"]
 		streams += data["streams"]
@@ -183,8 +183,8 @@ def follow_channel(target, user=None):
 	headers = {
 		"Authorization": "OAuth %s" % storage.data['twitch_oauth'][user],
 	}
-	yield from common.http.http_request_coro("https://api.twitch.tv/kraken/users/%s/follows/channels/%s" % (user, target),
-											 data={"notifications": "false"}, method="PUT", headers=headers)
+	yield from common.http.request_coro("https://api.twitch.tv/kraken/users/%s/follows/channels/%s" % (user, target),
+										data={"notifications": "false"}, method="PUT", headers=headers)
 
 @asyncio.coroutine
 def unfollow_channel(target, user=None):
@@ -193,13 +193,13 @@ def unfollow_channel(target, user=None):
 	headers = {
 		"Authorization": "OAuth %s" % storage.data['twitch_oauth'][user],
 	}
-	yield from common.http.http_request_coro("https://api.twitch.tv/kraken/users/%s/follows/channels/%s" % (user, target),
-											 method="DELETE", headers=headers)
+	yield from common.http.request_coro("https://api.twitch.tv/kraken/users/%s/follows/channels/%s" % (user, target),
+										method="DELETE", headers=headers)
 
 @asyncio.coroutine
 def get_videos(channel=None, offset=0, limit=10, broadcasts=False, hls=False):
 	channel = channel or config["channel"]
-	data = yield from common.http.http_request_coro("https://api.twitch.tv/kraken/channels/%s/videos" % channel, data={
+	data = yield from common.http.request_coro("https://api.twitch.tv/kraken/channels/%s/videos" % channel, data={
 		"offset": offset,
 		"limit": limit,
 		"broadcasts": "true" if broadcasts else "false",

--- a/start_bot.py
+++ b/start_bot.py
@@ -2,7 +2,6 @@
 
 import logging
 
-from lrrbot import chatlog
 from lrrbot.main import bot, log
 from common.config import config
 

--- a/webserver.py
+++ b/webserver.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import common.time
 import common.url
+import www.utils
 from common import utils
 from common.config import config
 from www.server import app
@@ -21,7 +22,7 @@ import www.quotes
 app.secret_key = config["session_secret"]
 app.add_template_filter(common.time.nice_duration)
 app.add_template_filter(utils.ucfirst)
-app.add_template_filter(utils.timestamp)
+app.add_template_filter(www.utils.timestamp)
 app.add_template_filter(common.url.https)
 app.add_template_filter(common.url.noproto)
 app.csrf_token = app.jinja_env.globals["csrf_token"]

--- a/webserver.py
+++ b/webserver.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import common.url
 from common import utils
 from common.config import config
 from www.server import app
@@ -20,8 +21,8 @@ app.secret_key = config["session_secret"]
 app.add_template_filter(utils.nice_duration)
 app.add_template_filter(utils.ucfirst)
 app.add_template_filter(utils.timestamp)
-app.add_template_filter(utils.https)
-app.add_template_filter(utils.noproto)
+app.add_template_filter(common.url.https)
+app.add_template_filter(common.url.noproto)
 app.csrf_token = app.jinja_env.globals["csrf_token"]
 app.jinja_env.globals["min"] = min
 app.jinja_env.globals["max"] = max

--- a/webserver.py
+++ b/webserver.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import common.time
 import common.url
 from common import utils
 from common.config import config
@@ -18,7 +19,7 @@ import www.api
 import www.quotes
 
 app.secret_key = config["session_secret"]
-app.add_template_filter(utils.nice_duration)
+app.add_template_filter(common.time.nice_duration)
 app.add_template_filter(utils.ucfirst)
 app.add_template_filter(utils.timestamp)
 app.add_template_filter(common.url.https)

--- a/www/archive.py
+++ b/www/archive.py
@@ -9,6 +9,7 @@ import flask.json
 import dateutil.parser
 import asyncio
 
+import common.url
 from common import utils
 from www import server
 from www import login
@@ -132,7 +133,7 @@ def get_player_url():
 	so get the real URL so we can serve it over the right protocol
 	"""
 	urls = asyncio.get_event_loop().run_until_complete(
-		utils.canonical_url("https://www-cdn.jtvnw.net/swflibs/TwitchPlayer.swf"))
+		common.url.canonical_url("https://www-cdn.jtvnw.net/swflibs/TwitchPlayer.swf"))
 	return urls[-1]
 
 @server.app.route('/archive/<videoid>')

--- a/www/archive.py
+++ b/www/archive.py
@@ -16,7 +16,6 @@ from common import utils
 from www import server
 from www import login
 
-
 CACHE_TIMEOUT = 5*60
 
 BEFORE_BUFFER = datetime.timedelta(minutes=15)

--- a/www/archive.py
+++ b/www/archive.py
@@ -9,6 +9,7 @@ import flask.json
 import dateutil.parser
 import asyncio
 
+import common.postgres
 import common.time
 import common.url
 from common import utils
@@ -102,7 +103,7 @@ def archive_feed():
 	rss = flask.render_template("archive_feed.xml", videos=archive_feed_data_html(channel, broadcasts, True), broadcasts=broadcasts)
 	return flask.Response(rss, mimetype="application/xml")
 
-@utils.with_postgres
+@common.postgres.with_postgres
 def chat_data(conn, cur, starttime, endtime, target="#loadingreadyrun"):
 	cur.execute("SELECT messagehtml FROM log WHERE target = %s AND time BETWEEN %s AND %s ORDER BY time ASC", (
 		target,

--- a/www/archive.py
+++ b/www/archive.py
@@ -9,6 +9,7 @@ import flask.json
 import dateutil.parser
 import asyncio
 
+import common.time
 import common.url
 from common import utils
 from www import server
@@ -138,7 +139,7 @@ def get_player_url():
 
 @server.app.route('/archive/<videoid>')
 def archive_watch(videoid):
-	starttime = utils.parsetime(flask.request.values.get('t'))
+	starttime = common.time.parsetime(flask.request.values.get('t'))
 	if starttime:
 		starttime = int(starttime.total_seconds())
 	video = get_video_data(videoid)

--- a/www/history.py
+++ b/www/history.py
@@ -4,7 +4,6 @@ import flask
 import flask.json
 
 import common.postgres
-from common import utils
 from www import server
 from www import login
 

--- a/www/history.py
+++ b/www/history.py
@@ -3,6 +3,7 @@ import difflib
 import flask
 import flask.json
 
+import common.postgres
 from common import utils
 from www import server
 from www import login
@@ -11,7 +12,7 @@ from psycopg2.extras import Json
 
 @server.app.route('/history')
 @login.require_mod
-@utils.with_postgres
+@common.postgres.with_postgres
 def history(conn, cur, session):
 	page = flask.request.values.get('page', 'all')
 	assert page in ('responses', 'explanations', 'spam', 'link_spam', 'all')
@@ -42,7 +43,7 @@ def history(conn, cur, session):
 
 @server.app.route('/history/<int:historykey>')
 @login.require_mod
-@utils.with_postgres
+@common.postgres.with_postgres
 def history_show(conn, cur, session, historykey):
 	cur.execute("""
 		SELECT section, changetime, changeuser, jsondata
@@ -68,7 +69,7 @@ def history_show(conn, cur, session, historykey):
 
 @server.app.route('/history/<int:fromkey>/<int:tokey>')
 @login.require_mod
-@utils.with_postgres
+@common.postgres.with_postgres
 def history_diff(conn, cur, session, fromkey, tokey):
 	cur.execute("""
 		SELECT section, changetime, changeuser, jsondata
@@ -182,7 +183,7 @@ def build_headdata(cur, fromkey, tokey, section, user, time):
 		"isdiff": fromkey != tokey,
 	}
 
-@utils.with_postgres
+@common.postgres.with_postgres
 def store(conn, cur, section, user, jsondata):
 	cur.execute("""
 		INSERT INTO history(section, changetime, changeuser, jsondata)

--- a/www/login.py
+++ b/www/login.py
@@ -6,6 +6,7 @@ import uuid
 import flask
 import flask.json
 
+import www.utils
 from common import utils
 from www import server
 from common.config import config, from_apipass
@@ -123,7 +124,7 @@ def login(return_to=None):
 
 		if 'as' in flask.request.values:
 			if flask.request.values['as'] not in SPECIAL_USERS:
-				return utils.error_page("Not a recognised user name: %s" % flask.request.values['as'])
+				return www.utils.error_page("Not a recognised user name: %s" % flask.request.values['as'])
 			scope = SPECIAL_USERS[flask.request.values['as']]
 		else:
 			scope = REQUEST_SCOPES

--- a/www/login.py
+++ b/www/login.py
@@ -7,7 +7,6 @@ import flask
 import flask.json
 
 import www.utils
-from common import utils
 from www import server
 from common.config import config, from_apipass
 

--- a/www/notifications.py
+++ b/www/notifications.py
@@ -6,6 +6,7 @@ import flask
 import flask.json
 from flaskext.csrf import csrf_exempt
 
+import common.postgres
 import common.time
 from common import utils
 from common.config import config
@@ -37,7 +38,7 @@ def get_notifications(cur, after=None, test=False):
 
 @server.app.route('/notifications')
 @login.with_session
-@utils.with_postgres
+@common.postgres.with_postgres
 def notifications(conn, cur, session):
 	row_data = get_notifications(cur)
 	for row in row_data:
@@ -58,7 +59,7 @@ def notifications(conn, cur, session):
 	return flask.render_template('notifications.html', row_data=row_data, maxkey=maxkey, session=session)
 
 @server.app.route('/notifications/updates')
-@utils.with_postgres
+@common.postgres.with_postgres
 def updates(conn, cur):
 	notifications = get_notifications(cur, int(flask.request.values['after']), True)
 	for n in notifications:
@@ -69,7 +70,7 @@ def updates(conn, cur):
 @csrf_exempt
 @server.app.route('/notifications/newmessage', methods=['POST'])
 @login.with_minimal_session
-@utils.with_postgres
+@common.postgres.with_postgres
 def new_message(conn, cur, session):
 	if session["user"] not in (config["username"], config["channel"]):
 		return flask.json.jsonify(error='apipass')

--- a/www/notifications.py
+++ b/www/notifications.py
@@ -1,4 +1,3 @@
-import time
 import datetime
 import pytz
 
@@ -12,7 +11,6 @@ from common import utils
 from common.config import config
 from www import server
 from www import login
-
 
 def get_notifications(cur, after=None, test=False):
 	if test:

--- a/www/notifications.py
+++ b/www/notifications.py
@@ -6,6 +6,7 @@ import flask
 import flask.json
 from flaskext.csrf import csrf_exempt
 
+import common.time
 from common import utils
 from common.config import config
 from www import server
@@ -43,7 +44,7 @@ def notifications(conn, cur, session):
 		if row['time'] is None:
 			row['duration'] = None
 		else:
-			row['duration'] = utils.nice_duration(datetime.datetime.now(row['time'].tzinfo) - row['time'], 2)
+			row['duration'] = common.time.nice_duration(datetime.datetime.now(row['time'].tzinfo) - row['time'], 2)
 	row_data.reverse()
 
 	if row_data:

--- a/www/quotes.py
+++ b/www/quotes.py
@@ -1,11 +1,9 @@
 import flask
-import math
 
 import common.postgres
 import www.utils
 from www import server
 from www import login
-from common import utils
 
 QUOTES_PER_PAGE = 25
 

--- a/www/quotes.py
+++ b/www/quotes.py
@@ -1,6 +1,7 @@
 import flask
 import math
 
+import common.postgres
 import www.utils
 from www import server
 from www import login
@@ -11,7 +12,7 @@ QUOTES_PER_PAGE = 25
 @server.app.route('/quotes/')
 @server.app.route('/quotes/<int:page>')
 @login.with_session
-@utils.with_postgres
+@common.postgres.with_postgres
 def quotes(conn, cur, session, page=1):
 	cur.execute("SELECT COUNT(*) FROM quotes WHERE NOT deleted")
 	count, = next(cur)
@@ -32,7 +33,7 @@ def quotes(conn, cur, session, page=1):
 
 @server.app.route('/quotes/search')
 @login.with_session
-@utils.with_postgres
+@common.postgres.with_postgres
 def quote_search(conn, cur, session):
 	query = flask.request.values["q"]
 	mode = flask.request.values.get('mode', 'text')
@@ -56,7 +57,7 @@ def quote_search(conn, cur, session):
 				LOWER(attrib_name) LIKE %s
 				AND NOT deleted
 			ORDER BY qid DESC
-		""", ("%" + utils.escape_like(query.lower()) + "%", ))
+		""", ("%" + common.postgres.escape_like(query.lower()) + "%",))
 	else:
 		return www.utils.error_page("Unrecognised mode")
 	pages = (cur.rowcount - 1) // QUOTES_PER_PAGE + 1

--- a/www/quotes.py
+++ b/www/quotes.py
@@ -1,5 +1,7 @@
 import flask
 import math
+
+import www.utils
 from www import server
 from www import login
 from common import utils
@@ -56,7 +58,7 @@ def quote_search(conn, cur, session):
 			ORDER BY qid DESC
 		""", ("%" + utils.escape_like(query.lower()) + "%", ))
 	else:
-		return utils.error_page("Unrecognised mode")
+		return www.utils.error_page("Unrecognised mode")
 	pages = (cur.rowcount - 1) // QUOTES_PER_PAGE + 1
 	page = max(1, min(page, pages))
 	cur.execute("SELECT * FROM cse OFFSET %s LIMIT %s", ((page-1) * QUOTES_PER_PAGE, QUOTES_PER_PAGE))

--- a/www/spam.py
+++ b/www/spam.py
@@ -1,6 +1,7 @@
 import flask
 import flask.json
 
+import common.postgres
 import common.url
 from www import server
 from www import login
@@ -131,7 +132,7 @@ def spam_test(session):
 
 @server.app.route('/spam/find')
 @login.require_mod
-@utils.with_postgres
+@common.postgres.with_postgres
 def spam_find(conn, cur, session):
 	rules = botinteract.get_data('spam_rules')
 	for rule in rules:

--- a/www/spam.py
+++ b/www/spam.py
@@ -1,5 +1,7 @@
 import flask
 import flask.json
+
+import common.url
 from www import server
 from www import login
 from www import botinteract
@@ -60,14 +62,14 @@ def do_check(line, rules):
 
 def do_check_links(message, rules):
 	loop = asyncio.get_event_loop()
-	re_url = loop.run_until_complete(utils.url_regex())
+	re_url = loop.run_until_complete(common.url.url_regex())
 	urls = []
 	for match in re_url.finditer(message):
 		for url in match.groups():
 			if url is not None:
 				urls.append(url)
 				break
-	canonical_urls = loop.run_until_complete(asyncio.gather(*map(utils.canonical_url, urls), loop=loop))
+	canonical_urls = loop.run_until_complete(asyncio.gather(*map(common.url.canonical_url, urls), loop=loop))
 	for url_chain in canonical_urls:
 		for url in url_chain:
 			for rule in rules:
@@ -79,7 +81,7 @@ def do_check_links(message, rules):
 @login.require_mod
 def spam_redirects(session):
 	loop = asyncio.get_event_loop()
-	redirects = loop.run_until_complete(utils.canonical_url(flask.request.values["url"].strip()))
+	redirects = loop.run_until_complete(common.url.canonical_url(flask.request.values["url"].strip()))
 	return flask.json.jsonify(redirects=redirects, csrf_token=server.app.csrf_token())
 
 @server.app.route('/spam/test', methods=['POST'])

--- a/www/spam.py
+++ b/www/spam.py
@@ -7,7 +7,6 @@ from www import server
 from www import login
 from www import botinteract
 from www import history
-from common import utils
 import re
 import datetime
 import pytz

--- a/www/stats.py
+++ b/www/stats.py
@@ -13,7 +13,7 @@ def stats(session):
 		show_id = show_id.lower()
 		games = shows.get(show_id, {}).get("games", {})
 		for game in games.values():
-		    game["show_id"] = show_id
+			game["show_id"] = show_id
 	else:
 		games = {}
 		for show_id, show in shows.items():

--- a/www/stats.py
+++ b/www/stats.py
@@ -53,7 +53,7 @@ def stats(session):
 	stats = list(stats.values())
 	stats.sort(key=lambda s: -s['total'])
 	# Calculate graph datasets
-	if 'show' in game:
+	if show_id is None:
 		game_name_format = "%(display)s (%(show)s)"
 	else:
 		game_name_format = "%(display)s"

--- a/www/utils.py
+++ b/www/utils.py
@@ -6,10 +6,8 @@ import pytz
 from common import config
 from www import login
 
-
 def error_page(message):
 	return flask.render_template("error.html", message=message, session=login.load_session(include_url=False))
-
 
 def timestamp(ts):
 	"""

--- a/www/utils.py
+++ b/www/utils.py
@@ -1,0 +1,25 @@
+import datetime
+
+import flask
+import pytz
+
+from common import config
+from www import login
+
+
+def error_page(message):
+	return flask.render_template("error.html", message=message, session=login.load_session(include_url=False))
+
+
+def timestamp(ts):
+	"""
+	Outputs a given time (either unix timestamp or datetime instance) as a human-readable time
+	and includes tags so that common.js will convert the time on page-load to the user's
+	timezone and preferred date/time format.
+	"""
+	if isinstance(ts, (int, float)):
+		ts = datetime.datetime.fromtimestamp(ts, tz=pytz.utc)
+	elif ts.tzinfo is None:
+		ts = ts.replace(tzinfo=datetime.timezone.utc)
+	ts = ts.astimezone(config.config['timezone'])
+	return flask.Markup("<span class=\"timestamp\" data-timestamp=\"{}\">{:%A, %-d %B, %Y %H:%M:%S %Z}</span>".format(ts.timestamp(), ts))


### PR DESCRIPTION
In addition to just moving code around:
* `_throttle_base` renamed to `throttle_base`.
* Removed `notify`, `modoverride` and `allowprivate` from `throttle_base`. They are now in `lrrbot.decorators.throttle`.
* Added two hooks to `throttle_base`: `bypass` and `cache_hit`. `throttle_base` no longer has bot specific code.
* Rewrote the moderator check from using `MODE` to checking metadata tags.
* Quote formatting is now in a single function.
* Removed `pick_random_row`. Replaced with `pick_random_elements`, which works with any iterator and can return multiple elements.
* Some bugfixes as well: `LRRBot.get_current_game_real` had disappeared and `/stats` page was throwing `UnboundLocalError`.