### PR TITLE
systemd support

### DIFF
--- a/lrrbot.service
+++ b/lrrbot.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=LoadingReadyLive chatbot
+
+[Service]
+Type=notify
+KillSignal=SIGINT
+TimeoutStartSec=5s
+WatchdogSec=120s
+Restart=always
+NotifyAccess=main
+WorkingDirectory=%h/lrrbot
+ExecStart=/usr/bin/env PYTHONASYNCIODEBUG= python3 %h/lrrbot/start_bot.py
+
+[Install]
+WantedBy=default.target

--- a/lrrbot/systemd.py
+++ b/lrrbot/systemd.py
@@ -1,0 +1,32 @@
+import logging
+import os
+
+log = logging.getLogger("lrrbot.systemd")
+
+try:
+    from systemd.daemon import notify
+except ImportError:
+    log.warning("`python-systemd` not installed")
+
+    def notify(status, unset_environment=False, pid=0, fds=None):
+        return False
+
+class Service:
+    def __init__(self, loop):
+        self.loop = loop
+
+        timeout_usec = os.environ.get("WATCHDOG_USEC")
+        if timeout_usec is not None:
+            self.timeout = (int(timeout_usec) * 1e-6) / 2
+            self.watchdog_handle = self.loop.call_later(self.timeout, self.watchdog)
+
+        self.subsystems = {"irc", "whispers"}
+
+    def watchdog(self):
+        notify("WATCHDOG=1")
+        self.watchdog_handle = self.loop.call_later(self.timeout, self.watchdog)
+
+    def subsystem_started(self, subsystem):
+        self.subsystems.remove(subsystem)
+        if self.subsystems == set():
+            notify("READY=1")

--- a/lrrbot/whisper.py
+++ b/lrrbot/whisper.py
@@ -8,8 +8,9 @@ import asyncio
 log = logging.getLogger('whisper')
 
 class TwitchWhisper(irc.bot.SingleServerIRCBot):
-	def __init__(self, loop):
+	def __init__(self, loop, service):
 		self.loop = loop
+		self.service = service
 		servers = [irc.bot.ServerSpec(
 			host=host,
 			port=port,
@@ -48,6 +49,7 @@ class TwitchWhisper(irc.bot.SingleServerIRCBot):
 		log.info("Connected to group chat server")
 		conn.cap("REQ", "twitch.tv/tags") # get metadata tags
 		conn.cap("REQ", "twitch.tv/commands") # get special commands
+		self.service.subsystem_started("whispers")
 
 	def add_whisper_handler(self, handler):
 		self.reactor.add_global_handler('whisper', handler)


### PR DESCRIPTION
`botscreen{,.sh}` is gone:
* `systemctl --user start lrrbot` to start the bot.
* `systemctl --user restart lrrbot` to restart the bot.
* `systemctl --user stop lrrbot` to stop the bot.
* `systemctl --user status lrrbot` to see the status and the last couple log entries.

I've set it up so to successfully start the bot it must connect to the main IRC servers and to the group chat servers (if the whispers are enabled of course). Because Twitch this can sometimes fail and you need to try again. Also if the bot gets stuck for more than two minutes it will be automatically restarted.