### PR TITLE
Add `users` table

### DIFF
--- a/alembic/versions/77dc71b483ed_users_foreign_keys.py
+++ b/alembic/versions/77dc71b483ed_users_foreign_keys.py
@@ -1,0 +1,67 @@
+revision = '77dc71b483ed'
+down_revision = 'a6854cd2e5f1'
+branch_labels = None
+depends_on = None
+
+import alembic
+import sqlalchemy
+import urllib.parse
+import requests
+import logging
+
+log = logging.getLogger("77dc71b483ed_users_foreign_keys")
+
+# People who know a guy at Twitch
+RENAMES = {
+	'a169': 'anubis169',
+	'dixonij': 'dix',
+}
+
+def upgrade():
+	conn = alembic.op.get_bind()
+	for old, new in RENAMES.items():
+		conn.execute("UPDATE history SET changeuser = %s WHERE changeuser = %s", new, old)
+
+	# Find missing users
+	names = [nick for nick, in conn.execute("""
+		(
+			SELECT nick as name FROM highlights
+			UNION
+			SELECT changeuser as name FROM history WHERE changeuser IS NOT NULL
+		)
+		EXCEPT
+		SELECT name FROM users
+	""")]
+	users = []
+	with requests.Session() as session:
+		for i, nick in enumerate(names):
+			log.info("Fetching %d/%d: %r", i + 1, len(names), nick)
+			try:
+				req = session.get("https://api.twitch.tv/kraken/users/%s" % urllib.parse.quote(nick))
+				req.raise_for_status()
+				user = req.json()
+				alembic.op.execute("INSERT INTO users (id, name, display_name) VALUES (%(_id)s, %(name)s, %(display_name)s)", user)
+			except:
+				log.exception("Failed to fetch data for %r", nick)
+				raise
+
+	alembic.op.add_column("highlights", sqlalchemy.Column("user", sqlalchemy.Integer, sqlalchemy.ForeignKey("users.id")))
+	alembic.op.execute("UPDATE highlights SET \"user\" = users.id FROM users WHERE highlights.nick = users.name")
+	alembic.op.drop_column("highlights", "nick")
+	alembic.op.alter_column("highlights", "user", nullable=False)
+
+	alembic.op.add_column("history", sqlalchemy.Column("changeuser2", sqlalchemy.Integer, sqlalchemy.ForeignKey("users.id")))
+	alembic.op.execute("UPDATE history SET changeuser2 = users.id FROM users WHERE history.changeuser = users.name")
+	alembic.op.drop_column("history", "changeuser")
+	alembic.op.alter_column("history", "changeuser2", new_column_name="changeuser")
+
+def downgrade():
+	alembic.op.add_column("highlights", sqlalchemy.Column("nick", sqlalchemy.Text))
+	alembic.op.execute("UPDATE highlights SET nick = users.name FROM users WHERE highlights.user = users.id")
+	alembic.op.drop_column("highlights", "user")
+	alembic.op.alter_column("highlights", "nick", nullable=False)
+
+	alembic.op.add_column("history", sqlalchemy.Column("changeuser2", sqlalchemy.Text))
+	alembic.op.execute("UPDATE history SET changeuser2 = users.name FROM users WHERE history.changeuser = users.id")
+	alembic.op.drop_column("history", "changeuser")
+	alembic.op.alter_column("history", "changeuser2", new_column_name="changeuser", nullable=False)

--- a/alembic/versions/a6854cd2e5f1_users.py
+++ b/alembic/versions/a6854cd2e5f1_users.py
@@ -1,0 +1,83 @@
+revision = 'a6854cd2e5f1'
+down_revision = '07ea7b63c8fc'
+branch_labels = None
+depends_on = None
+
+import alembic
+import sqlalchemy
+import json
+import urllib.parse
+import requests
+import logging
+
+log = logging.getLogger("a6854cd2e5f1_users")
+
+def upgrade():
+	users_table = alembic.op.create_table("users",
+		sqlalchemy.Column("id", sqlalchemy.Integer, primary_key=True, autoincrement=False),
+		sqlalchemy.Column("name", sqlalchemy.Text, nullable=False),
+		sqlalchemy.Column("display_name", sqlalchemy.Text),
+		sqlalchemy.Column("twitch_oauth", sqlalchemy.Text),
+		sqlalchemy.Column("is_sub", sqlalchemy.Boolean, nullable=False, server_default=sqlalchemy.false()),
+		sqlalchemy.Column("is_mod", sqlalchemy.Boolean, nullable=False, server_default=sqlalchemy.false()),
+		sqlalchemy.Column("autostatus", sqlalchemy.Boolean, nullable=False, server_default=sqlalchemy.false()),
+	)
+
+	datafile = alembic.context.config.get_section_option("lrrbot", "datafile", "data.json")
+	with open(datafile) as f:
+		data = json.load(f)
+
+	names = set()
+	names.update(data.get("autostatus", []))
+	names.update(data.get("subs", []))
+	names.update(data.get("mods", []))
+	names.update(data.get("twitch_oauth", {}).keys())
+	users = []
+	with requests.Session() as session:
+		for i, nick in enumerate(names):
+			log.info("Fetching %d/%d: %r", i + 1, len(names), nick)
+			try:
+				req = session.get("https://api.twitch.tv/kraken/users/%s" % urllib.parse.quote(nick))
+				req.raise_for_status()
+				user = req.json()
+				users.append({
+					"id": user["_id"],
+					"name": user["name"],
+					"display_name": user.get("display_name"),
+					"twitch_oauth": data.get("twitch_oauth", {}).get(nick),
+					"is_sub": nick in data.get("subs", []),
+					"is_mod": nick in data.get("mods", []),
+					"autostatus": nick in data.get("autostatus", []),
+				})
+			except Exception:
+				log.exception("Failed to fetch data for %r", nick)
+	alembic.op.bulk_insert(users_table, users)
+
+	for key in ["autostatus", "subs", "mods", "twitch_oauth"]:
+		try:
+			del data[key]
+		except KeyError:
+			pass
+	with open(datafile, "w") as f:
+		json.dump(data, f, indent=2, sort_keys=True)
+
+
+def downgrade():
+	conn = alembic.context.get_context().bind
+	meta = sqlalchemy.MetaData(bind=conn)
+	meta.reflect()
+	users = meta.tables["users"]
+
+	datafile = alembic.context.config.get_section_option("lrrbot", "datafile", "data.json")
+	with open(datafile) as f:
+		data = json.load(f)
+	data["autostatus"] = [nick for nick, in conn.execute(sqlalchemy.select([users.c.name]).where(users.c.autostatus))]
+	data["subs"] = [nick for nick, in conn.execute(sqlalchemy.select([users.c.name]).where(users.c.is_sub))]
+	data["mods"] = [nick for nick, in conn.execute(sqlalchemy.select([users.c.name]).where(users.c.is_mod))]
+	data["twitch_oauth"] = {
+		name: key
+		for name, key in conn.execute(sqlalchemy.select([users.c.name, users.c.twitch_oauth]).where(users.c.twitch_oauth != None))
+	}
+	with open(datafile, "w") as f:
+		json.dump(data, f, indent=2, sort_keys=True)
+	alembic.op.drop_table("users")

--- a/alembic/versions/d88d63c07199_.py
+++ b/alembic/versions/d88d63c07199_.py
@@ -1,0 +1,13 @@
+revision = 'd88d63c07199'
+down_revision = ('6387fbb406f3', '77dc71b483ed')
+branch_labels = None
+depends_on = None
+
+import alembic
+import sqlalchemy
+
+def upgrade():
+	pass
+
+def downgrade():
+	pass

--- a/common/config.py
+++ b/common/config.py
@@ -65,9 +65,6 @@ config.setdefault('siteurl', 'https://lrrbot.mrphlip.com/')
 # apipass - secret string needed to communicate with web site
 config["apipass"] = apipass.get(config["username"])
 
-# mods - comma-separated list of moderators for the bot, in addition to people with chanop privileges
-config['mods'] = set(i.strip().lower() for i in config.get('mods', 'd3fr0st5,mrphlip,lord_hosk,admiralmemo,dixonij').split(','))
-
 # datafile - file to store save data to
 config.setdefault('datafile', 'data.json')
 

--- a/highlights.py
+++ b/highlights.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 import common.postgres
-from lrrbot import twitch
+from common import twitch
 from common.highlights import SPREADSHEET, format_row
 from common import gdata
 
@@ -12,6 +12,7 @@ engine, metadata = common.postgres.new_engine_and_metadata()
 
 def get_staged_highlights():
 	highlights = metadata.tables["highlights"]
+	users = metadata.tables["users"]
 	with engine.begin() as conn:
 		return [{
 			"id": highlight[0],
@@ -20,8 +21,8 @@ def get_staged_highlights():
 			"time": highlight[3],
 			"nick": highlight[4],
 		} for highlight in conn.execute(sqlalchemy.select([
-			highlights.c.id, highlights.c.title, highlights.c.description, highlights.c.time, highlights.c.nick
-		])).fetchall()]
+			highlights.c.id, highlights.c.title, highlights.c.description, highlights.c.time, users.c.display_name
+		]).select_from(highlights.join(users, highlights.c.user == users.c.id)))]
 
 def delete_staged_highlights(highlights):
 	if len(highlights) == 0:

--- a/lrrbot/commands/game.py
+++ b/lrrbot/commands/game.py
@@ -2,8 +2,8 @@ import irc
 
 import lrrbot.decorators
 from common import utils
+from common import twitch
 from lrrbot import storage
-from lrrbot import twitch
 from lrrbot.main import bot
 from lrrbot.commands.show import show_name
 
@@ -60,7 +60,7 @@ def vote_respond(lrrbot, conn, respond_to, game):
 		good = sum(game["votes"].values())
 		count = len(game["votes"])
 		show = lrrbot.show_override or lrrbot.show
-		
+
 		conn.privmsg(respond_to, "Rating for %s on %s is now %.0f%% (%d/%d)" % (game_name(game), show_name(show), 100*good/count, good, count))
 	lrrbot.vote_update = None
 
@@ -89,15 +89,15 @@ def override_game(lrrbot, conn, event, respond_to, game):
 	"""
 	Command: !game override NAME
 	Section: info
-	
+
 	eg: !game override Prayer Warriors: A.O.F.G.
-	
+
 	Override what game is being played (eg when the current game isn't in the Twitch database)
 
 	--command
 	Command: !game override off
 	Section: info
-	
+
 	Disable override, go back to getting current game from Twitch stream settings.
 	Should the crew start regularly playing a game called "off", I'm sure we'll figure something out.
 	"""

--- a/lrrbot/commands/highlights.py
+++ b/lrrbot/commands/highlights.py
@@ -3,7 +3,7 @@ import irc.client
 import lrrbot.decorators
 from common import utils, gdata
 from common.highlights import SPREADSHEET, format_row
-from lrrbot import twitch
+from common import twitch
 from lrrbot.main import bot
 import asyncio
 
@@ -36,7 +36,7 @@ def highlight(lrrbot, conn, event, respond_to, description):
 	else:
 		with lrrbot.engine.begin() as pg_conn:
 			pg_conn.execute(lrrbot.metadata.tables["highlights"].insert(),
-				title=stream_info["status"], description=description, time=now, nick=irc.client.NickMask(event.source).nick)
+				title=stream_info["status"], description=description, time=now, user=event.tags["user-id"])
 		conn.privmsg(respond_to, "Highlight added.")
 		return
 

--- a/lrrbot/commands/live.py
+++ b/lrrbot/commands/live.py
@@ -1,8 +1,8 @@
 import common.http
 import lrrbot.decorators
 from lrrbot.main import bot
-from lrrbot import twitch
 from lrrbot import googlecalendar
+from common import twitch
 from common import utils
 from common.config import config
 import asyncio
@@ -10,10 +10,11 @@ import json
 import urllib.parse
 import urllib.error
 import irc.client
+import sqlalchemy
 
 @utils.cache(24 * 60 * 60)
 @asyncio.coroutine
-def extract_new_channels(loop):
+def extract_new_channels(loop, token):
 	data = yield from common.http.request_coro(googlecalendar.EVENTS_URL % urllib.parse.quote(googlecalendar.CALENDAR_FAN), {
 		"key": config["google_key"],
 		"maxResults": 25000,
@@ -39,7 +40,8 @@ def extract_new_channels(loop):
 	old_channels = {channel["channel"]["name"] for channel in follows}
 	old_channels.add(config["channel"])
 
-	yield from asyncio.gather(*map(twitch.follow_channel, channels.difference(old_channels)), loop=loop, return_exceptions=True)
+	futures = [twitch.follow_channel(channel, token) for channel in channels.difference(old_channels)]
+	yield from asyncio.gather(*futures, loop=loop, return_exceptions=True)
 
 @bot.command("live")
 @lrrbot.decorators.throttle()
@@ -47,16 +49,21 @@ def extract_new_channels(loop):
 def live(lrrbot, conn, event, respond_to):
 	"""
 	Command: !live
-	
+
 	Post the currenly live fanstreamers.
 	"""
 
+	users = lrrbot.metadata.tables["users"]
+	with lrrbot.engine.begin() as pg_conn:
+		token, = pg_conn.execute(sqlalchemy.select([users.c.twitch_oauth])
+			.where(users.c.name == config["username"])).first()
+
 	try:
-		yield from extract_new_channels(lrrbot.loop)
+		yield from extract_new_channels(lrrbot.loop, token)
 	except urllib.error.HTTPError:
 		pass
 
-	streams = yield from twitch.get_streams_followed()
+	streams = yield from twitch.get_streams_followed(token)
 	if streams == []:
 		return conn.privmsg(respond_to, "No fanstreamers currently live.")
 
@@ -105,7 +112,11 @@ def register_self(lrrbot, conn, event, respond_to):
 	Register your channel as a fanstreamer channel.
 	"""
 	channel = irc.client.NickMask(event.source).nick.lower()
-	yield from twitch.follow_channel(channel)
+	users = lrrbot.metadata.tables["users"]
+	with lrrbot.engine.begin() as pg_conn:
+		token, = pg_conn.execute(sqlalchemy.select([users.c.twitch_oauth])
+			.where(users.c.name == config["username"])).first()
+	yield from twitch.follow_channel(channel, token)
 	conn.privmsg(respond_to, "Channel '%s' added to the fanstreamer list." % channel)
 
 @bot.command("live unregister")
@@ -117,7 +128,11 @@ def unregister_self(lrrbot, conn, event, respond_to):
 	Unregister your channel as a fanstreamer channel.
 	"""
 	channel = irc.client.NickMask(event.source).nick.lower()
-	yield from twitch.unfollow_channel(channel)
+	users = lrrbot.metadata.tables["users"]
+	with lrrbot.engine.begin() as pg_conn:
+		token, = pg_conn.execute(sqlalchemy.select([users.c.twitch_oauth])
+			.where(users.c.name == config["username"])).first()
+	yield from twitch.unfollow_channel(channel, token)
 	conn.privmsg(respond_to, "Channel '%s' removed from the fanstreamer list." % channel)
 
 @bot.command("live register (.*)")
@@ -129,8 +144,12 @@ def register(lrrbot, conn, event, respond_to, channel):
 
 	Register CHANNEL as a fanstreamer channel.
 	"""
+	users = lrrbot.metadata.tables["users"]
+	with lrrbot.engine.begin() as pg_conn:
+		token, = pg_conn.execute(sqlalchemy.select([users.c.twitch_oauth])
+			.where(users.c.name == config["username"])).first()
 	try:
-		yield from twitch.follow_channel(channel)
+		yield from twitch.follow_channel(channel, token)
 		conn.privmsg(respond_to, "Channel '%s' added to the fanstreamer list." % channel)
 	except urllib.error.HTTPError:
 		conn.privmsg(respond_to, "'%s' isn't a Twitch channel." % channel)
@@ -144,8 +163,12 @@ def unregister(lrrbot, conn, event, respond_to, channel):
 
 	Unregister CHANNEL as a fanstreamer channel.
 	"""
+	users = lrrbot.metadata.tables["users"]
+	with lrrbot.engine.begin() as pg_conn:
+		token, = pg_conn.execute(sqlalchemy.select([users.c.twitch_oauth])
+			.where(users.c.name == config["username"])).first()
 	try:
-		yield from twitch.unfollow_channel(channel)
+		yield from twitch.unfollow_channel(channel, token)
 		conn.privmsg(respond_to, "Channel '%s' removed from the fanstreamer list." % channel)
 	except urllib.error.HTTPError:
 		conn.privmsg(respond_to, "'%s' isn't a Twitch channel." % channel)

--- a/lrrbot/commands/show.py
+++ b/lrrbot/commands/show.py
@@ -1,6 +1,6 @@
+from common import twitch
 import lrrbot.decorators
 from lrrbot import storage
-from lrrbot import twitch
 from lrrbot.main import bot
 
 def set_show(lrrbot, show):

--- a/lrrbot/whisper.py
+++ b/lrrbot/whisper.py
@@ -1,21 +1,23 @@
 import irc.bot, irc.client
 from common import utils
+from common import twitch
 from common.config import config
-from lrrbot import twitch, storage, asyncreactor
+from lrrbot import storage, asyncreactor
 import logging
 import asyncio
 
 log = logging.getLogger('whisper')
 
 class TwitchWhisper(irc.bot.SingleServerIRCBot):
-	def __init__(self, loop, service):
+	def __init__(self, password, loop, service):
+		assert password.startswith("oauth:")
 		self.loop = loop
 		self.service = service
 		servers = [irc.bot.ServerSpec(
 			host=host,
 			port=port,
-			password="oauth:%s" % storage.data['twitch_oauth'][config['username']] if config['password'] == "oauth" else config['password'],
-		) for host, port in twitch.get_group_servers()]
+			password=password,
+		) for host, port in twitch.get_group_servers(password[len("oauth:"):])]
 		super(TwitchWhisper, self).__init__(
 			server_list=servers,
 			realname=config['username'],

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ pubnub>=3.7.6
 alembic>=0.8.4
 sqlalchemy>=1.0.12
 flask-sqlalchemy>=2.1
+requests>=2.9.1

--- a/www/api.py
+++ b/www/api.py
@@ -1,5 +1,6 @@
 from www import server
 from www import botinteract
+from www import login
 from common.config import config
 import datetime
 
@@ -38,7 +39,10 @@ def api_votes():
 	return "%.0f%% (%d/%d)" % (100*good/count, good, count)
 
 @server.app.route("/api/show/<show>")
-def set_show(show):
+@login.with_minimal_session
+def set_show(session, show):
+	if not session['user']['is_mod']:
+		return "%s is not a mod" % (session['user']['display_name'])
 	if show == "off":
 		show = ""
 	response = botinteract.set_show(show)
@@ -55,5 +59,9 @@ def get_show():
 	return botinteract.get_show()
 
 @server.app.route("/api/tweet")
-def get_tweet():
-	return botinteract.get_tweet() or "-"
+@login.with_minimal_session
+def get_tweet(session):
+	tweet = None
+	if session['user']['is_mod']:
+		tweet = botinteract.get_tweet()
+	return tweet or "-"

--- a/www/botinteract.py
+++ b/www/botinteract.py
@@ -22,7 +22,7 @@ def send_bot_command(command, param, timeout=5, session=None):
 	data = {
 		"command": command,
 		"param": param,
-		"user": session['user'],
+		"user": session['user']['id'],
 	}
 	conn.send((flask.json.dumps(data) + "\n").encode())
 	buf = b""

--- a/www/commands.py
+++ b/www/commands.py
@@ -63,5 +63,5 @@ def commands_submit(session):
 		botinteract.modify_commands(data)
 	elif mode == 'explanations':
 		botinteract.modify_explanations(data)
-	history.store(mode, session['user'], data)
+	history.store(mode, session['user']['id'], data)
 	return flask.json.jsonify(success='OK', csrf_token=server.app.csrf_token())

--- a/www/login.py
+++ b/www/login.py
@@ -5,19 +5,34 @@ import uuid
 
 import flask
 import flask.json
+import sqlalchemy
 
 import www.utils
 from www import server
 from common.config import config, from_apipass
 from common import utils
+from common import twitch
+
+with server.db.engine.begin() as conn:
+	from_apipass = {
+		# FIXME: Raw SQL query. Needs https://bitbucket.org/zzzeek/sqlalchemy/issues/960
+		key: conn.execute("""
+			INSERT INTO users (id, name, display_name) VALUES (%(_id)s, %(name)s, %(display_name)s)
+			ON CONFLICT (id) DO UPDATE SET
+				name = EXCLUDED.name,
+				display_name = EXCLUDED.display_name
+			RETURNING id
+		""", twitch.get_user(name)).first()[0]
+		for key, name in from_apipass.items()
+	}
 
 # See https://github.com/justintv/Twitch-API/blob/master/authentication.md#scopes
 # We don't actually need, or want, any at present
 REQUEST_SCOPES = []
 
 SPECIAL_USERS = {
-	'lrrbot': ['chat_login', 'user_read', 'user_follows_edit'],
-	'loadingreadyrun': ['channel_subscriptions'],
+	config["username"]: ['chat_login', 'user_read', 'user_follows_edit'],
+	config["channel"]: ['channel_subscriptions'],
 }
 
 # Needs to be the URI of this script, and also the registered URI for the app
@@ -45,7 +60,7 @@ def with_minimal_session(func):
 	Pass the current login session information to the function
 
 	Do not include extra session information, intended for master.html. Useful for
-	places that need the current user id, but shouldn't (or don't need to) call
+	places that need the current user, but shouldn't (or don't need to) call
 	botinteract.
 
 	Usage:
@@ -68,7 +83,7 @@ def require_login(func):
 	@functools.wraps(func)
 	def wrapper(*args, **kwargs):
 		session = load_session()
-		if session['user']:
+		if session['user']['id'] is not None:
 			kwargs['session'] = session
 			return func(*args, **kwargs)
 		else:
@@ -84,9 +99,9 @@ def require_mod(func):
 	@functools.wraps(func)
 	def wrapper(*args, **kwargs):
 		session = load_session()
-		if session['user']:
+		if session['user']['id'] is not None:
 			kwargs['session'] = session
-			if session['header']['is_mod']:
+			if session['user']['is_mod']:
 				return func(*args, **kwargs)
 			else:
 				return flask.render_template('require_mod.html', session=session)
@@ -101,18 +116,59 @@ def load_session(include_url=True, include_header=True):
 	Includes all the information needed by the master.html template.
 	"""
 	from www import botinteract
-	# could potentially add other things here in the future...
-	session = {
-		"user": flask.session.get('user'),
-	}
+	user_id = flask.session.get('id')
+	user_name = flask.session.get('user')
+	if user_id is None and user_name is not None:
+		# Upgrade old session
+		with server.db.engine.begin() as conn:
+			# FIXME: Raw SQL query. Needs https://bitbucket.org/zzzeek/sqlalchemy/issues/960
+			user_id, = conn.execute("""
+				INSERT INTO users (id, name, display_name) VALUES (%(_id)s, %(name)s, %(display_name)s)
+				ON CONFLICT (id) DO UPDATE SET
+					name = EXCLUDED.name,
+					display_name = EXCLUDED.display_name
+				RETURNING id
+			""", twitch.get_user(user_name)).first()
+		flask.session["id"] = user_id
+	if 'name' in flask.session:
+		del flask.session["user"]
 	if 'apipass' in flask.request.values and flask.request.values['apipass'] in from_apipass:
-		session['user'] = from_apipass[flask.request.values["apipass"]]
+		user_id = from_apipass[flask.request.values["apipass"]]
+
+	session = {}
 	if include_url:
 		session['url'] = flask.request.url
 	else:
 		session['url'] = None
 	if include_header:
 		session['header'] = botinteract.get_header_info()
+	if user_id is not None:
+		users = server.db.metadata.tables["users"]
+		with server.db.engine.begin() as conn:
+			query = sqlalchemy.select([
+				users.c.name, sqlalchemy.func.coalesce(users.c.display_name, users.c.name), users.c.twitch_oauth,
+				users.c.is_sub, users.c.is_mod, users.c.autostatus,
+			]).where(users.c.id == user_id)
+			name, display_name, token, is_sub, is_mod, autostatus = conn.execute(query).first()
+			session['user'] = {
+				"id": user_id,
+				"name": name,
+				"display_name": display_name,
+				"twitch_oauth": token,
+				"is_sub": is_sub,
+				"is_mod": is_mod,
+				"autostatus": autostatus,
+			}
+	else:
+		session['user'] = {
+			"id": None,
+			"name": None,
+			"display_name": None,
+			"twitch_oauth": None,
+			"is_sub": False,
+			"is_mod": False,
+			"autostatus": False,
+		}
 	return session
 
 @server.app.route('/login')
@@ -178,8 +234,6 @@ def login(return_to=None):
 				raise Exception("No user name from Twitch: %s" % res_json)
 			user_name = res_object['token']['user_name'].lower()
 
-			# If this is one of our special users, store the access_token in the bot
-			# for future use
 			# If one of our special users logged in *without* using the "as" flag,
 			# Twitch *might* remember them and give us the same permissions anyway
 			# but if not, then we don't have the permissions we need to do our thing
@@ -189,15 +243,23 @@ def login(return_to=None):
 					server.app.logger.error("User %s has not granted us the required permissions" % user_name)
 					flask.session['login_nonce'] = uuid.uuid4().hex
 					return flask.render_template("login.html", clientid=config["twitch_clientid"], scope=' '.join(SPECIAL_USERS[user_name]), redirect_uri=REDIRECT_URI, nonce=flask.session['login_nonce'], session=load_session(include_url=False), special_user=user_name, remember_me=remember_me)
-				from www import botinteract
-				botinteract.set_data(["twitch_oauth", user_name], access_token)
 
-			# Store the user name into the session
-			# Note: we DON'T store the access_token in the session, as the session contents
-			# are user-visible (for the default Flask implementation) and the token needs
-			# to be kept secret. And we don't need it for anything other than verifying the
-			# user name anyway, for non-special users.
-			flask.session['user'] = user_name
+			# Store the user to the database
+			user = twitch.get_user(user_name)
+			user["twitch_oauth"] = access_token
+			with server.db.engine.begin() as conn:
+				# FIXME: Raw SQL query. Needs https://bitbucket.org/zzzeek/sqlalchemy/issues/960
+				conn.execute("""
+					INSERT INTO users (id, name, display_name, twitch_oauth)
+					VALUES (%(_id)s, %(name)s, %(display_name)s, %(twitch_oauth)s)
+					ON CONFLICT (id) DO UPDATE SET
+						name = EXCLUDED.name,
+						display_name = EXCLUDED.display_name,
+						twitch_oauth = EXCLUDED.twitch_oauth
+				""", user)
+
+			# Store the user ID into the session
+			flask.session['id'] = user["_id"]
 			flask.session.permanent = remember_me
 
 			return_to = flask.session.pop('login_return_to', None)
@@ -210,7 +272,7 @@ def login(return_to=None):
 
 @server.app.route('/logout')
 def logout():
-	if 'user' in flask.session:
-		del flask.session['user']
+	if 'id' in flask.session:
+		del flask.session['id']
 	session = load_session(include_url=False)
 	return flask.render_template("logout.html", return_to=flask.request.values.get('return_to'), session=session)

--- a/www/notifications.py
+++ b/www/notifications.py
@@ -74,7 +74,7 @@ def updates():
 @server.app.route('/notifications/newmessage', methods=['POST'])
 @login.with_minimal_session
 def new_message(session):
-	if session["user"] not in (config["username"], config["channel"]):
+	if not session["user"]["is_mod"]:
 		return flask.json.jsonify(error='apipass')
 	data = {
 		'message': flask.request.values['message'],

--- a/www/spam.py
+++ b/www/spam.py
@@ -49,7 +49,7 @@ def spam_submit(session):
 		botinteract.modify_link_spam_rules(data)
 	else:
 		botinteract.modify_spam_rules(data)
-	history.store("link_spam" if link_spam else "spam", session['user'], data)
+	history.store("link_spam" if link_spam else "spam", session['user']['id'], data)
 	return flask.json.jsonify(success='OK', csrf_token=server.app.csrf_token())
 
 def do_check(line, rules):

--- a/www/templates/help.html
+++ b/www/templates/help.html
@@ -16,7 +16,7 @@ $(modonly);
 {%endblock%}
 {%block content%}
 <h2>Commands</h2>
-<p><label><input type="checkbox" id="showmodonly" onclick="modonly()" {% if session['header']['is_mod'] %}checked{% endif %}> Show mod-only commands</label></p>
+<p><label><input type="checkbox" id="showmodonly" onclick="modonly()" {% if session['user']['is_mod'] %}checked{% endif %}> Show mod-only commands</label></p>
 {%for section in sections%}
 {%if commands[section] or section == "stats"%}
 <h3{%if commands[section] and commands[section]['mod-only']%} class="modonly"{%endif%}>{{sections[section]|e}}</h3>

--- a/www/templates/master.html
+++ b/www/templates/master.html
@@ -15,8 +15,8 @@
 <div class="header">
 	<h1><a href="{{url_for('index')|e}}"><img src="{{url_for('static', filename='logo.png')|e}}" alt="LRRbot" width="98" height="100"></a> {%block header%}{%endblock%}</h1>
 	<div class="login">
-		{%if session['user']%}
-			<a href="{{url_for('logout')|e}}{%if session['url']%}?return_to={{session['url']|urlencode|e}}{%endif%}">Log out ({{session['user']|e}})</a>
+		{%if session['user']['id'] is not none%}
+			<a href="{{url_for('logout')|e}}{%if session['url']%}?return_to={{session['url']|urlencode|e}}{%endif%}">Log out ({{session['user']['display_name']|e}})</a>
 		{%else%}
 			<a href="{{url_for('login')|e}}{%if session['url']%}?return_to={{session['url']|urlencode|e}}{%endif%}">Log in</a>
 		{%endif%}
@@ -58,7 +58,7 @@
 	<li><a href="{{url_for('archive')|e}}">Past Broadcasts</a></li>
 	<li><a href="{{url_for('archive')|e}}?highlights=true">Highlights</a></li>
 	<li><a href="{{url_for('quotes')|e}}">Quotes</a></li>
-	{%if session['header']['is_mod']%}
+	{%if session['user']['is_mod']%}
 	<li><a href="{{url_for('commands')|e}}">Responses</a></li>
 	<li><a href="{{url_for('commands')|e}}?mode=explanations">Explanations</a></li>
 	<li><a href="{{url_for('spam')|e}}">Spam</a></li>

--- a/www/votes.py
+++ b/www/votes.py
@@ -19,7 +19,7 @@ def votes(session):
 				"id": game_id,
 				"name": game["name"],
 				"display": game.get("display", game["name"]),
-				"vote": game.get("votes", {}).get(session["user"]),
+				"vote": game.get("votes", {}).get(session["user"]["name"]),
 			    } for game_id,game in show['games'].items()],
 			key=lambda game: (1 if game['id'] == current_game_id and show_id == current_show_id else 2, game['display'].upper()))
 	} for show_id, show in data.items()]
@@ -30,5 +30,5 @@ def votes(session):
 @server.app.route('/votes/submit', methods=['POST'])
 @login.require_login
 def vote_submit(session):
-	botinteract.set_data(['shows', flask.request.values['show'], 'games', flask.request.values['id'], 'votes', session['user']], bool(int(flask.request.values['vote'])))
+	botinteract.set_data(['shows', flask.request.values['show'], 'games', flask.request.values['id'], 'votes', session['user']['name']], bool(int(flask.request.values['vote'])))
 	return flask.json.jsonify(success='OK', csrf_token=server.app.csrf_token())


### PR DESCRIPTION
Replaces `"autostatus"`, `"mods"`, `"subs"` and `"twitch_oauth"` keys in `data.json`. The migration script fetches user IDs from Twitch for 3k users so it can take a while. Uses Postgres 9.5 `INSERT ... ON CONFLICT ... DO UPDATE ...` syntax.