### PR TITLE
Don't catch `BaseException`s.

### DIFF
--- a/common/http.py
+++ b/common/http.py
@@ -107,7 +107,7 @@ def api_request(uri, *args, **kwargs):
 		res = request(config.config['siteurl'] + uri, *args, **kwargs)
 	except utils.PASSTHROUGH_EXCEPTIONS:
 		raise
-	except:
+	except Exception:
 		log.exception("Error at server in %s" % uri)
 	else:
 		try:
@@ -125,7 +125,7 @@ def api_request_coro(uri, *args, **kwargs):
 		res = yield from request_coro(config.config['siteurl'] + uri, *args, **kwargs)
 	except utils.PASSTHROUGH_EXCEPTIONS:
 		raise
-	except:
+	except Exception:
 		log.exception("Error at server in %s" % uri)
 	else:
 		try:

--- a/common/utils.py
+++ b/common/utils.py
@@ -18,7 +18,7 @@ log = logging.getLogger('utils')
 
 # We usually don't want to catch these... so whenever we have an "except everything"
 # clause, we want to explicitly catch and re-raise these.
-PASSTHROUGH_EXCEPTIONS = (KeyboardInterrupt, SystemExit, asyncio.CancelledError)
+PASSTHROUGH_EXCEPTIONS = (asyncio.CancelledError, )
 
 def deindent(s):
 	def skipblank():
@@ -221,7 +221,7 @@ def swallow_errors(func):
 			return (yield from func(*args, **kwargs))
 		except PASSTHROUGH_EXCEPTIONS:
 			raise
-		except:
+		except Exception:
 			log.exception("Exception in " + func.__name__)
 			return None
 	return wrapper
@@ -239,7 +239,7 @@ def check_exception(future):
 		future.result()
 	except PASSTHROUGH_EXCEPTIONS:
 		raise
-	except:
+	except Exception:
 		log.exception("Exception in future")
 
 def immutable(obj):

--- a/lrrbot/chatlog.py
+++ b/lrrbot/chatlog.py
@@ -256,7 +256,7 @@ def get_display_name(nick):
 		return data['display_name']
 	except utils.PASSTHROUGH_EXCEPTIONS:
 		raise
-	except:
+	except Exception:
 		return nick
 
 re_just_words = re.compile("^\w+$")
@@ -310,7 +310,7 @@ def get_twitch_emotes():
 		return (yield from get_twitch_emotes_official())
 	except utils.PASSTHROUGH_EXCEPTIONS:
 		raise
-	except:
+	except Exception:
 		return (yield from get_twitch_emotes_undocumented())
 
 @asyncio.coroutine
@@ -323,6 +323,6 @@ def get_filtered_emotes(setids):
 		return emotes.values()
 	except utils.PASSTHROUGH_EXCEPTIONS:
 		raise
-	except:
+	except Exception:
 		log.exception("Error fetching emotes")
 		return []

--- a/lrrbot/main.py
+++ b/lrrbot/main.py
@@ -331,7 +331,7 @@ class LRRBot(irc.bot.SingleServerIRCBot, linkspam.LinkSpam):
 				channel_info = twitch.get_info_uncached(user)
 			except utils.PASSTHROUGH_EXCEPTIONS:
 				raise
-			except:
+			except Exception:
 				pass
 			else:
 				if channel_info.get('logo'):
@@ -540,7 +540,7 @@ class RPCServer(asyncio.Protocol):
 				response = self.lrrbot.on_server_event(request)
 			except utils.PASSTHROUGH_EXCEPTIONS:
 				raise
-			except:
+			except Exception:
 				log.exception("Exception in on_server_event")
 				response = {'success': False, 'result': ''.join(traceback.format_exc())}
 			else:

--- a/www/archive.py
+++ b/www/archive.py
@@ -125,7 +125,7 @@ def get_video_data(videoid):
 		}
 	except utils.PASSTHROUGH_EXCEPTIONS:
 		raise
-	except:
+	except Exception:
 		return None
 
 @server.app.route('/archive/<videoid>')

--- a/www/login.py
+++ b/www/login.py
@@ -204,7 +204,7 @@ def login(return_to=None):
 			return flask.render_template("login_response.html", success=True, return_to=return_to, session=load_session(include_url=False))
 		except utils.PASSTHROUGH_EXCEPTIONS:
 			raise
-		except:
+		except Exception:
 			server.app.logger.exception("Exception in login")
 			return flask.render_template("login_response.html", success=False, session=load_session(include_url=False))
 


### PR DESCRIPTION
There are still two bare `except`s in `lrrbot.chatlog.do_rebuild_all` and  `common.utils.log_errors`. Those do some cleanup actions and immediately re-`raise` them.