### PR TITLE
Move code out of `lrrbot.main`

### DIFF
--- a/lrrbot/command_parser.py
+++ b/lrrbot/command_parser.py
@@ -1,0 +1,77 @@
+import asyncio
+import logging
+import re
+
+import irc.client
+
+from common import utils
+from common.config import config
+
+log = logging.getLogger('command_parser')
+
+class CommandParser:
+	def __init__(self, lrrbot, loop):
+		self.lrrbot = lrrbot
+		self.loop = loop
+
+		self.commands = {}
+		self.command_groups = {}
+		self.re_botcommand = None
+
+		self.lrrbot.reactor.add_global_handler('pubmsg', self.on_message, 99)
+		self.lrrbot.reactor.add_global_handler('privmsg', self.on_message, 99)
+
+	def add(self, pattern, function):
+		if not asyncio.iscoroutinefunction(function):
+			function = asyncio.coroutine(function)
+		pattern = pattern.replace(" ", r"(?:\s+)")
+		self.commands[pattern] = {
+			"groups": re.compile(pattern, re.IGNORECASE).groups,
+			"func": function,
+		}
+		self.re_botcommand = None
+
+	def remove(self, pattern):
+		del self.commands[pattern.replace(" ", r"(?:\s+)")]
+		self.re_botcommand = None
+
+	def decorator(self, pattern):
+		def wrapper(function):
+			self.add(pattern, function)
+			return function
+		return wrapper
+
+	def compile(self):
+		self.re_botcommand = r"^\s*%s\s*(?:" % re.escape(config["commandprefix"])
+		self.re_botcommand += "|".join(map(lambda re: '(%s)' % re, self.commands))
+		self.re_botcommand += r")\s*$"
+		self.re_botcommand = re.compile(self.re_botcommand, re.IGNORECASE)
+
+		i = 1
+		for val in self.commands.values():
+			self.command_groups[i] = (val["func"], i+val["groups"])
+			i += 1 + val["groups"]
+
+	def on_message(self, conn, event):
+		source = irc.client.NickMask(event.source)
+		nick = source.nick.lower()
+
+		# If the message was sent to a channel, respond in the channel
+		# If it was sent via PM, respond via PM
+		if event.type == "pubmsg":
+			respond_to = event.target
+		else:
+			respond_to = source.nick
+		if self.lrrbot.access == "mod" and not self.is_mod(event):
+			return
+		if self.lrrbot.access == "sub" and not self.is_mod(event) and not self.is_sub(event):
+			return
+		if self.re_botcommand is None:
+			self.compile()
+		command_match = self.re_botcommand.match(event.arguments[0])
+		if command_match:
+			command = command_match.group(command_match.lastindex)
+			log.info("Command from %s: %s " % (source.nick, command))
+			proc, end = self.command_groups[command_match.lastindex]
+			params = command_match.groups()[command_match.lastindex:end]
+			asyncio.async(proc(self.lrrbot, conn, event, respond_to, *params), loop=self.loop).add_done_callback(utils.check_exception)

--- a/lrrbot/commands/explain.py
+++ b/lrrbot/commands/explain.py
@@ -11,7 +11,7 @@ def explain_response(lrrbot, conn, event, respond_to, command):
 	Command: !explain TOPIC
 	Mod-Only: true
 	Section: text
-	
+
 	Provide an explanation for a given topic.
 	--command
 	Command: !explain show
@@ -41,6 +41,8 @@ def explain_response(lrrbot, conn, event, respond_to, command):
 		response = random.choice(response)
 	conn.privmsg(respond_to, response)
 
-def modify_explanations(commands):
+@bot.rpc_server.function()
+def modify_explanations(lrrbot, user, commands):
+	log.info("Setting explanations (%s) to %r" % (user, commands))
 	storage.data["explanations"] = {k.lower(): v for k,v in commands.items()}
 	storage.save()

--- a/lrrbot/commands/misc.py
+++ b/lrrbot/commands/misc.py
@@ -268,3 +268,15 @@ def autostatus_set(lrrbot, conn, event, respond_to, enable):
 		conn.privmsg(source.nick, "Auto-status enabled.")
 	else:
 		conn.privmsg(source.nick, "Auto-status disabled.")
+
+def autostatus_on_join(conn, event):
+	source = irc.client.NickMask(event.source)
+	users = bot.metadata.tables["users"]
+	with bot.engine.begin() as pg_conn:
+		res = pg_conn.execute(sqlalchemy.select([users.c.autostatus])
+			.where(users.c.name == source.nick)).first()
+		if res is not None:
+			enabled, = res
+			if res[0]:
+				send_status(bot, conn, source.nick)
+bot.reactor.add_global_handler('join', autostatus_on_join, 99)

--- a/lrrbot/commands/static.py
+++ b/lrrbot/commands/static.py
@@ -56,7 +56,9 @@ def static_response(lrrbot, conn, event, respond_to, command):
 		response = random.choice(response)
 	conn.privmsg(respond_to, response)
 
-def modify_commands(commands):
+@bot.rpc_server.function()
+def modify_commands(lrrbot, user, commands):
+	log.info("Setting commands (%s) to %r" % (user, commands))
 	storage.data["responses"] = {" ".join(k.lower().split()): v for k,v in commands.items()}
 	storage.save()
 	generate_hook()
@@ -65,9 +67,9 @@ command_expression = None
 def generate_hook():
 	global command_expression
 	if command_expression is not None:
-		bot.remove_command(command_expression)
+		bot.commands.remove(command_expression)
 	static_response.__doc__ = generate_docstring()
 	command_expression = generate_expression()
-	bot.add_command(command_expression, static_response)
+	bot.commands.add(command_expression, static_response)
 
 generate_hook()

--- a/lrrbot/linkspam.py
+++ b/lrrbot/linkspam.py
@@ -3,16 +3,18 @@ import re
 import logging
 
 import common.url
+from common import utils
 from lrrbot import storage
 import irc.client
 
 log = logging.getLogger('linkspam')
 
 class LinkSpam:
-	def __init__(self, loop):
-		self._loop = loop
-		self._re_url = loop.run_until_complete(common.url.url_regex())
-		self._rules = [
+	def __init__(self, lrrbot, loop):
+		self.loop = loop
+		self.lrrbot = lrrbot
+		self.re_url = loop.run_until_complete(common.url.url_regex())
+		self.rules = [
 			{
 				"re": re.compile(rule["re"], re.IGNORECASE),
 				"message": rule["message"],
@@ -20,12 +22,13 @@ class LinkSpam:
 			}
 			for rule in storage.data.get("link_spam_rules", [])
 		]
-		self.add_server_event("modify_link_spam_rules", self.modify_link_spam_rules)
+		self.lrrbot.rpc_server.add("modify_link_spam_rules", self.modify_link_spam_rules)
+		self.lrrbot.reactor.add_global_handler("pubmsg", self.check_link_spam, 21)
 
 	def modify_link_spam_rules(self, lrrbot, user, data):
 		storage.data['link_spam_rules'] = data
 		storage.save()
-		self._rules = [
+		self.rules = [
 			{
 				"re": re.compile(rule['re'], re.IGNORECASE),
 				"message": rule['message'],
@@ -34,22 +37,25 @@ class LinkSpam:
 			for rule in storage.data['link_spam_rules']
 		]
 
+	def check_link_spam(self, conn, event):
+		asyncio.async(self.check_urls(conn, event, event.arguments[0])).add_done_callback(utils.check_exception)
+
 	@asyncio.coroutine
 	def check_urls(self, conn, event, message):
 		urls = []
-		for match in self._re_url.finditer(message):
+		for match in self.re_url.finditer(message):
 			for url in match.groups():
 				if url is not None:
 					urls.append(url)
 					break
-		canonical_urls = yield from asyncio.gather(*map(common.url.canonical_url, urls), loop=self._loop)
+		canonical_urls = yield from asyncio.gather(*map(common.url.canonical_url, urls), loop=self.loop)
 		for original_url, url_chain in zip(urls, canonical_urls):
 			for url in url_chain:
-				for rule in self._rules:
+				for rule in self.rules:
 					match = rule["re"].search(url)
 					if match is not None:
 						source = irc.client.NickMask(event.source)
 						log.info("Detected link spam from %s - %r contains the URL %r which redirects to %r which matches %r",
 							source.nick, message, original_url, url, rule["re"].pattern)
-						yield from self.ban(conn, event, rule["message"] % {str(i+1): v for i, v in enumerate(match.groups())}, rule['type'])
+						yield from self.lrrbot.ban(conn, event, rule["message"] % {str(i+1): v for i, v in enumerate(match.groups())}, rule['type'])
 						return

--- a/lrrbot/spam.py
+++ b/lrrbot/spam.py
@@ -1,0 +1,45 @@
+import asyncio
+import re
+import logging
+
+import common.url
+from common import utils
+from lrrbot import storage
+import irc.client
+
+log = logging.getLogger('spam')
+
+class Spam:
+	def __init__(self, lrrbot, loop):
+		self.loop = loop
+		self.lrrbot = lrrbot
+		self.rules = [
+			(re.compile(rule["re"]), rule["message"], rule.get('type', 'spam'))
+			for rule in storage.data.get("spam_rules", [])
+		]
+		self.lrrbot.rpc_server.add("modify_spam_rules", self.modify_spam_rules)
+		self.lrrbot.reactor.add_global_handler("pubmsg", self.check_spam, 20)
+
+	def modify_spam_rules(self, lrrbot, user, data):
+		log.info("Setting spam rules (%s) to %r" % (user, data))
+		storage.data['spam_rules'] = data
+		storage.save()
+		self.rules = [
+			(re.compile(rule['re']), rule['message'], rule.get('type', 'spam'))
+			for rule in storage.data['spam_rules']
+		]
+
+	def check_spam(self, conn, event):
+		"""Check the message against spam detection rules"""
+		message = event.arguments[0]
+		source = irc.client.NickMask(event.source)
+
+		for re, desc, type in self.rules:
+			matches = re.search(message)
+			if matches:
+				log.info("Detected spam from %s - %r matches %s" % (source.nick, message, re.pattern))
+				groups = {str(i+1):v for i,v in enumerate(matches.groups())}
+				desc = desc % groups
+				asyncio.async(self.lrrbot.ban(conn, event, desc, type), loop=self.loop).add_done_callback(utils.check_exception)
+				# Halt message handling
+				return "NO MORE"

--- a/lrrbot/twitchsubs.py
+++ b/lrrbot/twitchsubs.py
@@ -1,52 +1,146 @@
 import time
+import re
 import logging
+import datetime
 import dateutil
 import asyncio
 import sqlalchemy
+import irc.client
 from common import utils
 from common.config import config
 from common import twitch
+from common import http
+from lrrbot import storage
 
 log = logging.getLogger('twitchsubs')
 
-@asyncio.coroutine
-def watch_subs(lrrbot):
-	try:
-		while True:
-			yield from do_check(lrrbot)
-			yield from asyncio.sleep(config['checksubstime'])
-	except asyncio.CancelledError:
-		pass
+class TwitchSubs:
+	def __init__(self, lrrbot, loop):
+		self.lrrbot = lrrbot
+		self.loop = loop
+		self.last_subs = None
+		self.last_announced_subs = []
 
-last_subs = None
-@utils.swallow_errors
-@asyncio.coroutine
-def do_check(lrrbot):
-	global last_subs
+		# Precompile regular expressions
+		self.re_subscription = re.compile(r"^(.*) just subscribed!$", re.IGNORECASE)
+		self.re_resubscription = re.compile(r"^(.*) subscribed for (\d+) months? in a row!$", re.IGNORECASE)
 
-	users = lrrbot.metadata.tables["users"]
-	with lrrbot.engine.begin() as conn:
-		token, = conn.execute(sqlalchemy.select([users.c.twitch_oauth])
-			.where(users.c.name == config['channel'])).first()
+		self.lrrbot.reactor.add_global_handler('privmsg', self.on_notification, 90)
+		self.lrrbot.reactor.add_global_handler('pubmsg', self.on_notification, 90)
 
-	sublist = None
-	if token is not None:
-		sublist = yield from twitch.get_subscribers(config['channel'], token)
-	if not sublist:
-		log.info("Failed to get subscriber list from Twitch")
-		last_subs = None
-		return
+	@asyncio.coroutine
+	def watch_subs(self):
+		try:
+			while True:
+				yield from self.do_check()
+				yield from asyncio.sleep(config['checksubstime'])
+		except asyncio.CancelledError:
+			pass
 
-	# If this is the first time we've gotten the sub list then don't notify for all of them
-	# as all of them will appear "new" even if we saw them on a previous run
-	# Just add them to the "seen" list
-	if last_subs is not None:
-		for user, logo, eventtime in sublist:
-			if user.lower() not in last_subs:
-				log.info("Found new subscriber via Twitch API: %s" % user)
-				eventtime = dateutil.parser.parse(eventtime).timestamp()
-				lrrbot.on_api_subscriber(user, logo, eventtime, config['channel'])
-	else:
-		log.debug("Got initial subscriber list from Twitch")
+	@utils.swallow_errors
+	@asyncio.coroutine
+	def do_check(self):
+		users = self.lrrbot.metadata.tables["users"]
+		with self.lrrbot.engine.begin() as conn:
+			token, = conn.execute(sqlalchemy.select([users.c.twitch_oauth])
+				.where(users.c.name == config['channel'])).first()
 
-	last_subs = [i[0].lower() for i in sublist]
+		sublist = None
+		if token is not None:
+			sublist = yield from twitch.get_subscribers(config['channel'], token)
+		if not sublist:
+			log.info("Failed to get subscriber list from Twitch")
+			self.last_subs = None
+			return
+
+		# If this is the first time we've gotten the sub list then don't notify for all of them
+		# as all of them will appear "new" even if we saw them on a previous run
+		# Just add them to the "seen" list
+		if self.last_subs is not None:
+			for user, logo, eventtime in sublist:
+				if user.lower() not in self.last_subs:
+					log.info("Found new subscriber via Twitch API: %s" % user)
+					eventtime = dateutil.parser.parse(eventtime).timestamp()
+					if user.lower() not in self.last_announced_subs:
+						self.on_subscriber(self.lrrbot.connection, "#%s" % config['channel'], user, eventtime, logo)
+		else:
+			log.debug("Got initial subscriber list from Twitch")
+
+		self.last_subs = [i[0].lower() for i in sublist]
+
+	def on_notification(self, conn, event):
+		"""Handle notification messages from Twitch, sending the message up to the web"""
+		source = irc.client.NickMask(event.source)
+		if source.nick != config['notifyuser']:
+			return
+
+		respond_to = "#%s" % config["channel"]
+		log.info("Notification: %s" % event.arguments[0])
+		subscribe_match = self.re_subscription.match(event.arguments[0])
+		if subscribe_match and irc.client.is_channel(event.target):
+			# Don't highlight the same sub via both the chat and the API
+			if subscribe_match.group(1).lower() not in self.last_announced_subs:
+				self.on_subscriber(conn, event.target, subscribe_match.group(1), time.time())
+			# Halt message processing
+			return "NO MORE"
+
+		subscribe_match = self.re_resubscription.match(event.arguments[0])
+		if subscribe_match and irc.client.is_channel(event.target):
+			if subscribe_match.group(1).lower() not in self.last_announced_subs:
+				self.on_subscriber(conn, event.target, subscribe_match.group(1), time.time(), monthcount=int(subscribe_match.group(2)))
+			# Halt message processing
+			return "NO MORE"
+
+		notifyparams = {
+			'apipass': config['apipass'],
+			'message': event.arguments[0],
+			'eventtime': time.time(),
+		}
+		if irc.client.is_channel(event.target):
+			notifyparams['channel'] = event.target[1:]
+		http.api_request('notifications/newmessage', notifyparams, 'POST')
+		# Halt message processing
+		return "NO MORE"
+
+	def on_subscriber(self, conn, channel, user, eventtime, logo=None, monthcount=None):
+		notifyparams = {
+			'apipass': config['apipass'],
+			'message': "%s just subscribed!" % user,
+			'eventtime': eventtime,
+			'subuser': user,
+			'channel': channel,
+		}
+
+		if logo is None:
+			try:
+				channel_info = twitch.get_info_uncached(user)
+			except utils.PASSTHROUGH_EXCEPTIONS:
+				raise
+			except Exception:
+				pass
+			else:
+				if channel_info.get('logo'):
+					notifyparams['avatar'] = channel_info['logo']
+		else:
+			notifyparams['avatar'] = logo
+
+		if monthcount is not None:
+			notifyparams['monthcount'] = monthcount
+
+		# have to get this in a roundabout way as datetime.date.today doesn't take a timezone argument
+		today = datetime.datetime.now(config['timezone']).date().toordinal()
+		if today != storage.data.get("storm",{}).get("date"):
+			storage.data["storm"] = {
+				"date": today,
+				"count": 0,
+			}
+		storage.data["storm"]["count"] += 1
+		self.last_announced_subs.append(user.lower())
+		self.last_announced_subs = self.last_announced_subs[-10:]
+		storage.save()
+		conn.privmsg(channel, "lrrSPOT Thanks for subscribing, %s! (Today's storm count: %d)" % (notifyparams['subuser'], storage.data["storm"]["count"]))
+		http.api_request('notifications/newmessage', notifyparams, 'POST')
+
+		users = self.lrrbot.metadata.tables["users"]
+		with self.lrrbot.engine.begin() as conn:
+			conn.execute(users.update().where(users.c.name == user), is_sub=True)

--- a/start_bot.py
+++ b/start_bot.py
@@ -14,8 +14,6 @@ if config['logfile'] is not None:
 logging.getLogger("requests").setLevel(logging.ERROR)
 
 import lrrbot.commands
-import lrrbot.serverevents
-bot.compile()
 
 try:
 	log.info("Bot startup")


### PR DESCRIPTION
I used `irc`'s event handlers to link the code back together.

`'privmsg'` and `'pubmsg'` handers:

Priority | Handler
-------- | -------
0 | add wrapper to `Connection.privmsg` 
1 | check message tags
2 | add message to chat log
20 | spam filter
21 | link spam filter
90 | notifications
99 | commands

Priorities 0-19 would deal with the IRC protocol, 20-89 would be filters and 90-99 would process the messages.

