### PR TITLE
update: added context to quotes, usuable by appending ' | context' to…

### DIFF
--- a/alembic/versions/988883a6be1d_add_context_to_quotes.py
+++ b/alembic/versions/988883a6be1d_add_context_to_quotes.py
@@ -1,0 +1,23 @@
+revision = '988883a6be1d'
+down_revision = 'd88d63c07199'
+branch_labels = None
+depends_on = None
+
+import alembic
+import sqlalchemy
+
+def upgrade():
+	alembic.op.add_column('quotes',
+ 		sqlalchemy.Column('context', sqlalchemy.Text, nullable=True)
+	)
+	alembic.op.add_column('quotes',
+ 		sqlalchemy.Column('game', sqlalchemy.Text, nullable=True)
+	)
+	alembic.op.add_column('quotes',
+ 		sqlalchemy.Column('show', sqlalchemy.Text, nullable=True)
+	)
+
+def downgrade():
+	alembic.op.drop_column('quotes', 'context')
+	alembic.op.drop_column('quotes', 'game')
+	alembic.op.drop_column('quotes', 'show')

--- a/www/quotes.py
+++ b/www/quotes.py
@@ -20,7 +20,7 @@ def quotes(session, page=1):
 		page = max(1, min(page, pages))
 
 		quotes = conn.execute(sqlalchemy.select([
-			quotes.c.id, quotes.c.quote, quotes.c.attrib_name, quotes.c.attrib_date,
+			quotes.c.id, quotes.c.quote, quotes.c.attrib_name, quotes.c.attrib_date, quotes.c.context
 		]).where(~quotes.c.deleted).order_by(quotes.c.id.desc()).offset((page-1) * QUOTES_PER_PAGE).limit(QUOTES_PER_PAGE)).fetchall()
 
 	return flask.render_template('quotes.html', session=session, quotes=quotes, page=page, pages=pages)

--- a/www/templates/quotes.html
+++ b/www/templates/quotes.html
@@ -18,13 +18,14 @@
 {%endblock%}
 {%block pagecontent%}
 <ol class="quotes">
-{% for qid, quote, name, date in quotes %}
+{% for qid, quote, name, date, context in quotes %}
 <li value="{{qid|e}}" {%if loop.first%}class="first"{%endif%}>
 	<div class="num">#{{qid|e}}</div>
 	<blockquote>{{quote|e}}</blockquote>
-	{% if name or date %}
+	{% if name or date or context %}
 	<div class="attrib">&#8212;
-		{% if name %}{{name|e}}{% endif %}
+		{% if name %}{{name|e}}{% if context %}, {% endif %}{% endif %}
+		{% if context %}{{context|e}}{% endif %}
 		{% if date %}<span class="date">[{{date|e}}]</span>{% endif %}
 	</div>
 	{% endif %}


### PR DESCRIPTION
… existing quotes. Also added game and show to quote fields those these are otherwise unused

https://github.com/mrphlip/lrrbot/issues/165

Implements a context field for quotes and begins to store game and show information for new quotes. 

Context is added to the quote after the name attribution and before date. For example:
`"!addquote (Cam) [now] I hate Dark Souls | while paving the save after fighting Capra demon"`
Returns:
`New quote #24: "This game's awful" —Cam, while paving the save after fighting Capra demon [2016-03-29]`

Context modification using !modquote was also added. 

Currently game and show are not added to the quotes by the bot or on the site (formatting with extra information became unwieldy and reduced the humour of the quote), but if we plan on using them in the future it may be useful to begin collecting them in quotes as early as possible.

I chose pipe as the delimiter for context but we could also use {} or <> to maintain the precedent of other metadata for quotes. The only usuability issue currently is ensuring a space before and after the pipe to ensure the command is recognised.
