### PR TITLE
Detect emote spam

### DIFF
--- a/lrrbot/emote_spam.py
+++ b/lrrbot/emote_spam.py
@@ -1,0 +1,49 @@
+import asyncio
+import json
+
+from common import http
+from common import utils
+
+MAXCOST = 40
+
+@asyncio.coroutine
+def emote_sets():
+    data = yield from http.request_coro("https://api.twitch.tv/kraken/chat/emoticon_images")
+    emotes = json.loads(data)["emoticons"]
+
+    code_to_set = {}
+    for emote in emotes:
+        code_to_set[emote["id"]] = emote["emoticon_set"] or 0
+
+    return code_to_set
+
+class EmoteSpam:
+    def __init__(self, lrrbot, loop):
+        self.lrrbot = lrrbot
+        self.loop = loop
+
+        self.emote_sets = self.loop.run_until_complete(emote_sets())
+
+        self.lrrbot.reactor.add_global_handler('pubmsg', self.check_emotes, 22)
+
+    def emote_cost(self, emote_id):
+        set_id = self.emote_sets[emote_id]
+        if set_id == 0:
+            return 8
+        else:
+            return 5
+
+    def check_emotes(self, conn, event):
+        emotes = event.tags.get('emotes') or ''
+        if len(emotes) == 0:
+            return
+
+        cost = 0
+        for emote in emotes.split('/'):
+            emote_id, positions = emote.split(':')
+            positions = positions.split(',')
+            cost += self.emote_cost(int(emote_id)) * len(positions)
+
+        if cost > MAXCOST:
+            asyncio.async(self.lrrbot.ban(conn, event, "emote spam", "censor"), loop=self.loop).add_done_callback(utils.check_exception)
+            return "NO MORE"

--- a/lrrbot/main.py
+++ b/lrrbot/main.py
@@ -23,6 +23,7 @@ from lrrbot import spam
 from lrrbot import command_parser
 from lrrbot import rpc
 from lrrbot import join_filter
+from lrrbot import emote_spam
 
 log = logging.getLogger('lrrbot')
 
@@ -114,6 +115,7 @@ class LRRBot(irc.bot.SingleServerIRCBot):
 		self.spam = spam.Spam(self, loop)
 		self.subs = twitchsubs.TwitchSubs(self, loop)
 		self.join_filter = join_filter.JoinFilter(self, loop)
+		self.emote_spam = emote_spam.EmoteSpam(self, loop)
 
 	def reactor_class(self):
 		return asyncreactor.AsyncReactor(self.loop)


### PR DESCRIPTION
Allows up to 8 subscriber emotes from any channel (and possibly Turbo emotes?) or up to 5 global emotes. Uses cost system so that it behaves reasonably when mixing emotes.
