### PR TITLE
Move game data to database

### DIFF
--- a/alembic/versions/affc03cb46f5_game_data.py
+++ b/alembic/versions/affc03cb46f5_game_data.py
@@ -1,0 +1,339 @@
+revision = 'affc03cb46f5'
+down_revision = '988883a6be1d'
+branch_labels = None
+depends_on = None
+
+import alembic
+import sqlalchemy
+import json
+import itertools
+import requests
+import logging
+import urllib.parse
+
+log = logging.getLogger("affc03cb46f5_game_data")
+
+def upgrade():
+	conn = alembic.context.get_context().bind
+	meta = sqlalchemy.MetaData(bind=conn)
+	meta.reflect()
+	users = meta.tables["users"]
+	all_users = dict(conn.execute(sqlalchemy.select([users.c.name, users.c.id])).fetchall())
+
+	shows = alembic.op.create_table(
+		"shows",
+		sqlalchemy.Column("id", sqlalchemy.Integer, primary_key=True),
+		sqlalchemy.Column("string_id", sqlalchemy.Text, nullable=False, unique=True),
+		sqlalchemy.Column("name", sqlalchemy.Text, nullable=False),
+	)
+
+	alembic.op.execute(sqlalchemy.schema.CreateSequence(sqlalchemy.Sequence("games_id_seq", start=-1, increment=-1)))
+	games = alembic.op.create_table(
+		"games",
+		sqlalchemy.Column("id", sqlalchemy.Integer, sqlalchemy.Sequence("game_id_seq"), primary_key=True, server_default=sqlalchemy.func.nextval('games_id_seq')),
+		sqlalchemy.Column("name", sqlalchemy.Text, unique=True, nullable=False),
+	)
+	alembic.op.execute("ALTER SEQUENCE games_id_seq OWNED BY games.id")
+
+	game_per_show_data = alembic.op.create_table(
+		"game_per_show_data",
+		sqlalchemy.Column("game_id", sqlalchemy.Integer, sqlalchemy.ForeignKey("games.id", ondelete="CASCADE", onupdate="CASCADE"), nullable=False),
+		sqlalchemy.Column("show_id", sqlalchemy.Integer, sqlalchemy.ForeignKey("shows.id", ondelete="CASCADE", onupdate="CASCADE"), nullable=False),
+		sqlalchemy.Column("display_name", sqlalchemy.Text),
+		sqlalchemy.Column("verified", sqlalchemy.Boolean),
+	)
+	alembic.op.create_primary_key("game_per_show_data_pk", "game_per_show_data", ["game_id", "show_id"])
+
+	stats = alembic.op.create_table(
+		"stats",
+		sqlalchemy.Column("id", sqlalchemy.Integer, primary_key=True),
+		sqlalchemy.Column("string_id", sqlalchemy.Text, nullable=False, unique=True),
+		sqlalchemy.Column("singular", sqlalchemy.Text),
+		sqlalchemy.Column("plural", sqlalchemy.Text),
+		sqlalchemy.Column("emote", sqlalchemy.Text),
+	)
+
+	game_stats = alembic.op.create_table(
+		"game_stats",
+		sqlalchemy.Column("game_id", sqlalchemy.Integer, sqlalchemy.ForeignKey("games.id", ondelete="CASCADE", onupdate="CASCADE"), nullable=False),
+		sqlalchemy.Column("show_id", sqlalchemy.Integer, sqlalchemy.ForeignKey("shows.id", ondelete="CASCADE", onupdate="CASCADE"), nullable=False),
+		sqlalchemy.Column("stat_id", sqlalchemy.Integer, sqlalchemy.ForeignKey("shows.id", ondelete="CASCADE", onupdate="CASCADE"), nullable=False),
+		sqlalchemy.Column("count", sqlalchemy.Integer, nullable=False),
+	)
+	alembic.op.create_primary_key("game_stats_pk", "game_stats", ["game_id", "show_id", "stat_id"])
+
+	game_votes = alembic.op.create_table(
+		"game_votes",
+		sqlalchemy.Column("game_id", sqlalchemy.Integer, sqlalchemy.ForeignKey("games.id", ondelete="CASCADE", onupdate="CASCADE"), nullable=False),
+		sqlalchemy.Column("show_id", sqlalchemy.Integer, sqlalchemy.ForeignKey("shows.id", ondelete="CASCADE", onupdate="CASCADE"), nullable=False),
+		sqlalchemy.Column("user_id", sqlalchemy.Integer, sqlalchemy.ForeignKey("users.id", ondelete="CASCADE", onupdate="CASCADE"), nullable=False),
+		sqlalchemy.Column("vote", sqlalchemy.Boolean, nullable=False),
+	)
+	alembic.op.create_primary_key("game_votes_pk", "game_votes", ["game_id", "show_id", "user_id"])
+
+	disabled_stats = alembic.op.create_table(
+		"disabled_stats",
+		sqlalchemy.Column("show_id", sqlalchemy.Integer, sqlalchemy.ForeignKey("shows.id", ondelete="CASCADE", onupdate="CASCADE"), nullable=False),
+		sqlalchemy.Column("stat_id", sqlalchemy.Integer, sqlalchemy.ForeignKey("stats.id", ondelete="CASCADE", onupdate="CASCADE"), nullable=False),
+	)
+	alembic.op.create_primary_key("disabled_stats_pk", "disabled_stats", ["show_id", "stat_id"])
+
+	# Move data
+	datafile = alembic.context.config.get_section_option("lrrbot", "datafile", "data.json")
+	with open(datafile) as f:
+		data = json.load(f)
+
+	# stats
+	alembic.op.bulk_insert(stats, [{
+		"string_id": string_id,
+		"emote": values.get("emote"),
+		"plural": values.get("plural"),
+		"singular": values.get("singular"),
+	} for string_id, values in data.get("stats", {}).items()])
+	all_stats = dict(conn.execute(sqlalchemy.select([stats.c.string_id, stats.c.id])).fetchall())
+
+	# shows
+	alembic.op.bulk_insert(shows, [{
+		"string_id": show,
+		"name": values["name"],
+	} for show, values in data.get("shows", {}).items()])
+	all_shows = dict(conn.execute(sqlalchemy.select([shows.c.string_id, shows.c.id])).fetchall())
+
+	# games
+	def parse_id(id):
+		if id is None:
+			return None
+		try:
+			return int(id)
+		except ValueError:
+			return None
+	for show in data.get("shows", {}).values():
+		for game_id, game in show.get("games", {}).items():
+			game_id = parse_id(game_id) or parse_id(game.get("id"))
+			if game_id is None:
+				conn.execute("INSERT INTO games (name) VALUES (%(name)s) ON CONFLICT (name) DO NOTHING", {"name": game["name"]})
+			else:
+				conn.execute("""
+					INSERT INTO games (
+						id,
+						name
+					) VALUES (
+						%(id)s,
+						%(name)s
+					) ON CONFLICT (name) DO UPDATE SET
+						id = EXCLUDED.id
+				""", {"id": game_id, "name": game["name"]})
+	all_games = dict(conn.execute(sqlalchemy.select([games.c.name, games.c.id])).fetchall())
+
+	# game_per_show_data
+	display_names = []
+	for show_id, show in data.get("shows", {}).items():
+		for game in show.get("games", {}).values():
+			if "display" in game:
+				display_names.append({
+					"show_id": all_shows[show_id],
+					"game_id": parse_id(game.get("id")) or all_games[game["name"]],
+					"display_name": game["display"],
+				})
+	alembic.op.bulk_insert(game_per_show_data, display_names)
+
+	# game_stats
+	all_game_stats = []
+	for show_id, show in data.get("shows", {}).items():
+		for game in show.get("games", {}).values():
+			game_id = parse_id(game.get("id")) or all_games[game["name"]]
+			for stat, count in game.get("stats", {}).items():
+				all_game_stats.append({
+					"show_id": all_shows[show_id],
+					"game_id": game_id,
+					"stat_id": all_stats[stat],
+					"count": count,
+				})
+	alembic.op.bulk_insert(game_stats, all_game_stats)
+
+	# game_votes
+	all_votes = []
+	with requests.Session() as session:
+		for show_id, show in data.get("shows", {}).items():
+			for game in show.get("games", {}).values():
+				game_id = parse_id(game.get("id")) or all_games[game["name"]]
+				for nick, vote in game.get("votes", {}).items():
+					if nick not in all_users:
+						try:
+							req = session.get("https://api.twitch.tv/kraken/users/%s" % urllib.parse.quote(nick))
+							req.raise_for_status()
+							user = req.json()
+							all_users[nick] = user["_id"]
+							alembic.op.bulk_insert(users, [{
+								"id": user["_id"],
+								"name": user["name"],
+								"display_name": user.get("display_name"),
+							}])
+						except Exception:
+							log.exception("Failed to fetch data for %r", nick)
+							all_users[nick] = None
+					if all_users[nick] is None:
+						continue
+					all_votes.append({
+						"show_id": all_shows[show_id],
+						"game_id": game_id,
+						"user_id": all_users[nick],
+						"vote": vote,
+					})
+	alembic.op.bulk_insert(game_votes, all_votes)
+
+	# disabled_stats
+	if "swiftlycam" in all_shows:
+		for_cameron = []
+		if "death" in all_stats:
+			for_cameron.append({
+				"show_id": all_shows["swiftlycam"],
+				"stat_id": all_stats["death"]
+			})
+		if "tilt" in all_stats:
+			for_cameron.append({
+				"show_id": all_shows["swiftlycam"],
+				"stat_id": all_stats["tilt"]
+			})
+		if "pave" in all_stats:
+			for_cameron.append({
+				"show_id": all_shows["swiftlycam"],
+				"stat_id": all_stats["pave"],
+			})
+		alembic.op.bulk_insert(disabled_stats, for_cameron)
+
+	alembic.op.add_column("quotes", sqlalchemy.Column("game_id", sqlalchemy.Integer, sqlalchemy.ForeignKey("games.id", ondelete="CASCADE", onupdate="CASCADE")))
+	alembic.op.add_column("quotes", sqlalchemy.Column("show_id", sqlalchemy.Integer, sqlalchemy.ForeignKey("shows.id", ondelete="CASCADE", onupdate="CASCADE")))
+	alembic.op.execute("""
+		UPDATE quotes
+		SET
+			show_id = shows.id
+		FROM shows
+		WHERE quotes.show = shows.name
+	""")
+	alembic.op.execute("""
+		UPDATE quotes
+		SET
+			game_id = game_per_show_data.game_id
+		FROM game_per_show_data
+		WHERE quotes.game = game_per_show_data.display_name AND game_per_show_data.show_id = quotes.show_id
+	""")
+	alembic.op.execute("""
+		UPDATE quotes
+		SET
+			game_id = games.id
+		FROM games
+		WHERE quotes.game = games.name
+	""")
+	alembic.op.drop_column("quotes", "game")
+	alembic.op.drop_column("quotes", "show")
+
+	del data["shows"]
+	del data["stats"]
+	with open(datafile, "w") as f:
+		json.dump(data, f, indent=2, sort_keys=True)
+
+def downgrade():
+	conn = alembic.context.get_context().bind
+	meta = sqlalchemy.MetaData(bind=conn)
+	meta.reflect()
+
+	datafile = alembic.context.config.get_section_option("lrrbot", "datafile", "data.json")
+	with open(datafile) as f:
+		data = json.load(f)
+
+	data["stats"] = {}
+	stats = meta.tables["stats"]
+	for id, singular, plural, emote in conn.execute(sqlalchemy.select([stats.c.string_id, stats.c.singular, stats.c.plural, stats.c.emote])):
+		data["stats"][id] = {}
+		if singular is not None:
+			data["stats"][id]["singular"] = singular
+		if plural is not None:
+			data["stats"][id]["plural"] = plural
+		if emote is not None:
+			data["stats"][id]["emote"] = emote
+
+	data["shows"] = {}
+	shows = meta.tables["shows"]
+	games = meta.tables["games"]
+	game_per_show_data = meta.tables["game_per_show_data"]
+	game_votes = meta.tables["game_votes"]
+	game_stats = meta.tables["game_stats"]
+	users = meta.tables["users"]
+	for fkey, id, name in conn.execute(sqlalchemy.select([shows.c.id, shows.c.string_id, shows.c.name])).fetchall():
+		data["shows"][id] = {"name": name, "games": {}}
+		query = sqlalchemy.select([games.c.id, games.c.name, stats.c.string_id, game_stats.c.count])
+		query = query.select_from(
+			game_stats
+				.join(games, game_stats.c.game_id == games.c.id)
+				.join(stats, game_stats.c.stat_id == stats.c.id)
+		)
+		query = query.where(game_stats.c.show_id == fkey)
+		for game_id, name, stat_id, count in conn.execute(query).fetchall():
+			if game_id < 0:
+				game_id = name
+			else:
+				game_id = str(game_id)
+			data["shows"][id]["games"].setdefault(game_id, {"id": game_id, "name": name, "stats": {}, "votes": {}})["stats"][stat_id] = count
+		query = sqlalchemy.select([games.c.id, games.c.name, users.c.name, game_votes.c.vote])
+		query = query.select_from(
+			game_votes
+				.join(games, game_votes.c.game_id == games.c.id)
+				.join(users, game_votes.c.user_id == users.c.id)
+		)
+		query = query.where(game_votes.c.show_id == fkey)
+		for game_id, name, user, vote in conn.execute(query).fetchall():
+			if game_id < 0:
+				game_id = name
+			else:
+				game_id = str(game_id)
+			data["shows"][id]["games"].setdefault(game_id, {"id": game_id, "name": name, "stats": {}, "votes": {}})["votes"][user] = vote
+		query = sqlalchemy.select([games.c.id, games.c.name, game_per_show_data.c.display_name])
+		query = query.select_from(
+			game_per_show_data.join(games, game_per_show_data.c.game_id == games.c.id)
+		)
+		query = query.where(game_per_show_data.c.show_id == fkey)
+		for game_id, name, display_name in conn.execute(query).fetchall():
+			if game_id < 0:
+				game_id = name
+			else:
+				game_id = str(game_id)
+			if display_name is not None:
+				data["shows"][id]["games"].setdefault(game_id, {"id": game_id, "name": name, "stats": {}, "votes": {}})["display"] = display_name
+
+	alembic.op.add_column("quotes", sqlalchemy.Column("game", sqlalchemy.Text))
+	alembic.op.add_column("quotes", sqlalchemy.Column("show", sqlalchemy.Text))
+	alembic.op.execute("""
+		UPDATE quotes
+		SET
+			show = shows.name
+		FROM shows
+		WHERE quotes.show_id = shows.id
+	""")
+	alembic.op.execute("""
+		UPDATE quotes
+		SET
+			game = games.name
+		FROM games
+		WHERE quotes.game_id = games.id
+	""")
+	alembic.op.execute("""
+		UPDATE quotes
+		SET
+			game = game_per_show_data.display_name
+		FROM game_per_show_data
+		WHERE quotes.game_id = game_per_show_data.game_id AND game_per_show_data.show_id = quotes.show_id
+	""")
+	alembic.op.drop_column("quotes", "game_id")
+	alembic.op.drop_column("quotes", "show_id")
+
+	alembic.op.drop_table("disabled_stats")
+	alembic.op.drop_table("game_votes")
+	alembic.op.drop_table("game_stats")
+	alembic.op.drop_table("stats")
+	alembic.op.drop_table("game_per_show_data")
+	alembic.op.drop_table("games")
+	alembic.op.drop_table("shows")
+
+	with open(datafile, "w") as f:
+		json.dump(data, f, indent=2, sort_keys=True)

--- a/common/game_data.py
+++ b/common/game_data.py
@@ -1,0 +1,149 @@
+import contextlib
+import sqlalchemy
+
+TABLES = [
+	"game_per_show_data",
+	"game_stats",
+	"game_votes",
+	"games",
+	"quotes",
+]
+
+def lock_tables(conn, metadata):
+	" Lock all tables that reference the `games` table "
+	conn.execute("LOCK TABLE " + ", ".join(TABLES) + " IN ACCESS EXCLUSIVE MODE")
+
+def merge_games(conn, metadata, old_id, new_id, result_id):
+	"""
+	NOT THREADSAFE. Use `lock_tables` before calling `merge_games`. `old_id`, `new_id` and
+	`result_id` must already exist in the database.
+	"""
+
+	if old_id == result_id and new_id == result_id:
+		return
+
+	quotes = metadata.tables["quotes"]
+	conn.execute(quotes.update().where(quotes.c.game_id.in_({old_id, new_id})), {
+		"game_id": result_id,
+	})
+
+	game_stats = metadata.tables["game_stats"]
+	conn.execute("""
+		INSERT INTO game_stats (
+			game_id,
+			show_id,
+			stat_id,
+			count
+		) SELECT
+			%(result_id)s,
+			show_id,
+			stat_id,
+			SUM(count)
+		FROM
+			game_stats
+		WHERE
+			game_id = %(old_id)s OR game_id = %(new_id)s
+		GROUP BY (show_id, stat_id)
+		ON CONFLICT (game_id, show_id, stat_id) DO UPDATE SET
+			count = EXCLUDED.count
+	""", {
+		"result_id": result_id,
+		"old_id": old_id,
+		"new_id": new_id,
+	})
+	conn.execute(game_stats.delete().where(game_stats.c.game_id.in_({old_id, new_id} - {result_id})))
+
+	game_votes = metadata.tables["game_votes"]
+	try:
+		with conn.begin_nested():
+			conn.execute(game_votes.update().where(game_votes.c.game_id.in_({old_id, new_id})), {
+				"game_id": result_id,
+			})
+	except sqlalchemy.exc.IntegrityError:
+		with conn.begin_nested():
+			res = conn.execute(sqlalchemy.select([
+				game_votes.c.show_id, game_votes.c.user_id, game_votes.c.vote
+			]).where(game_votes.c.game_id == old_id))
+
+			votes = {
+				(show_id, user_id): vote
+				for show_id, user_id, vote in res
+			}
+
+			res = conn.execute(sqlalchemy.select([
+				game_votes.c.show_id, game_votes.c.user_id, game_votes.c.vote
+			]).where(game_votes.c.game_id == new_id))
+
+			votes.update({
+				(show_id, user_id): vote
+				for show_id, user_id, vote in res
+			})
+
+			conn.execute(game_votes.delete().where(game_votes.c.game_id.in_({old_id, new_id})))
+			conn.execute(game_votes.insert(), [
+				{
+					"game_id": result_id,
+					"show_id": show_id,
+					"user_id": user_id,
+					"vote": vote
+				}
+				for (show_id, user_id), vote in votes.items()
+			])
+
+	game_per_show_data = metadata.tables["game_per_show_data"]
+	try:
+		with conn.begin_nested():
+			conn.execute(game_per_show_data.update()
+				.where(game_per_show_data.c.game_id.in_({old_id, new_id})), {
+				"game_id": result_id,
+			})
+	except sqlalchemy.exc.IntegrityError:
+		with conn.begin_nested():
+			res = conn.execute(sqlalchemy.select([
+				game_per_show_data.c.show_id, game_per_show_data.c.display_name,
+				game_per_show_data.c.verified
+			]).where(game_per_show_data.c.game_id == old_id))
+
+			data = {
+				show_id: (display_name, verified)
+				for show_id, display_name, verified in res
+			}
+
+			res = conn.execute(sqlalchemy.select([
+				game_per_show_data.c.show_id, game_per_show_data.c.display_name,
+				game_per_show_data.c.verifed
+			]).where(game_per_show_data.c.game_id == new_id))
+
+			for show_id, new_display_name, new_verified in res:
+				old_display_name, old_verified = data.get(show_id, (None, None))
+				data[show_id] = (
+					new_display_name or old_display_name,
+					new_verified if new_verified is not None else old_verified
+				)
+
+			conn.execute(game_per_show_data.delete()
+				.where(game_per_show_data.c.game_id.in_({old_id, new_id})))
+			conn.execute(game_per_show_data.insert(), [
+				{
+					"game_id": result_id,
+					"show_id": show_id,
+					"display_name": display_name,
+					"verified": verified,
+				}
+				for show_id, (display_name, verified) in data.items()
+			])
+
+	games = metadata.tables["games"]
+	conn.execute(games.delete().where(games.c.id.in_({old_id, new_id} - {result_id})))
+
+def stat_plural(stats, count):
+	plural = sqlalchemy.func.coalesce(stats.c.plural,
+		sqlalchemy.func.coalesce(stats.c.singular, stats.c.string_id).concat("s")
+	)
+	if count is not None:
+		return sqlalchemy.case(
+			{1: sqlalchemy.func.coalesce(stats.c.singular, stats.c.string_id)},
+			value=count,
+			else_=plural,
+		)
+	return plural

--- a/common/utils.py
+++ b/common/utils.py
@@ -9,6 +9,7 @@ import random
 import socket
 import textwrap
 import time
+import heapq
 
 import werkzeug.datastructures
 
@@ -320,3 +321,13 @@ def pick_random_elements(iterable, k):
 			ret[j] = elem
 
 	return ret
+
+def pick_weighted_random_elements(iterable, k):
+	queue = []
+	for elem, weight in iterable:
+		r = random.random() ** (1 / weight)
+		if len(queue) < k:
+			heapq.heappush(queue, (r, elem))
+		elif queue[0][0] < r:
+			heapq.heapreplace(queue, (r, elem))
+	return [elem for r, elem in queue]

--- a/lrrbot/commands/game.py
+++ b/lrrbot/commands/game.py
@@ -1,14 +1,12 @@
 import irc
+import sqlalchemy
 
 import lrrbot.decorators
 from common import utils
 from common import twitch
 from lrrbot import storage
 from lrrbot.main import bot
-from lrrbot.commands.show import show_name
-
-def game_name(game):
-	return game.get("display", game["name"])
+from lrrbot.commands.stats import stat_increment
 
 @bot.command("game")
 @lrrbot.decorators.throttle()
@@ -19,17 +17,38 @@ def current_game(lrrbot, conn, event, respond_to):
 
 	Post the game currently being played.
 	"""
-	game = lrrbot.get_current_game()
-	if game is None:
-		message = "Not currently playing any game"
-	else:
-		message = "Currently playing: %s" % game_name(game)
-		if game.get("votes"):
-			good = sum(game["votes"].values())
-			message += " (rating %.0f%%)" % (100*good/len(game["votes"]))
-	if lrrbot.game_override is not None:
-		message += " (overridden)"
-	conn.privmsg(respond_to, message)
+	game_id = lrrbot.get_game_id()
+	if game_id is None:
+		conn.privmsg(respond_to, "Not currently playing any game")
+		return
+	show_id = lrrbot.get_show_id()
+
+	game_votes = lrrbot.metadata.tables["game_votes"]
+	game_per_show_data = lrrbot.metadata.tables["game_per_show_data"]
+	games = lrrbot.metadata.tables["games"]
+	with lrrbot.engine.begin() as pg_conn:
+		good = sqlalchemy.cast(
+			sqlalchemy.func.sum(sqlalchemy.cast(game_votes.c.vote, sqlalchemy.Integer)),
+			sqlalchemy.Numeric
+		)
+		votes_query = sqlalchemy.alias(sqlalchemy.select([
+			(100 * good / sqlalchemy.func.count(game_votes.c.vote)).label("rating")
+		]).where(game_votes.c.game_id == game_id).where(game_votes.c.show_id == show_id))
+		game, rating = pg_conn.execute(
+			sqlalchemy.select([
+				sqlalchemy.func.coalesce(game_per_show_data.c.display_name, games.c.name),
+				votes_query.c.rating
+			]).select_from(
+				games.outerjoin(game_per_show_data,
+					(game_per_show_data.c.game_id == games.c.id)
+						& (game_per_show_data.c.show_id == show_id))
+			).where(games.c.id == game_id)).first()
+
+		conn.privmsg(respond_to, "Currently playing: %s%s%s" % (
+			game,
+			" (rating %0.0f%%)" % rating if rating is not None else "",
+			" (overridden)" if lrrbot.game_override is not None else ""
+		))
 
 @bot.command("game (?:(good|yes|:\)|:D|<3|lrrAWESOME|lrrGOAT|lrrSPOT)|(bad|no|:\(|:/|>\(|lrrAWW|lrrEFF|lrrFRUMP))")
 def vote(lrrbot, conn, event, respond_to, vote_good, vote_bad):
@@ -43,25 +62,66 @@ def vote(lrrbot, conn, event, respond_to, vote_good, vote_bad):
 	host may heed this or ignore it at their choice. Probably ignore
 	it.
 	"""
-	game = lrrbot.get_current_game(readonly=False)
-	if game is None:
+	game_id = lrrbot.get_game_id()
+	if game_id is None:
 		conn.privmsg(respond_to, "Not currently playing any game")
 		return
-	nick = irc.client.NickMask(event.source).nick
-	game.setdefault("votes", {})
-	game["votes"][nick.lower()] = vote_good is not None
-	storage.save()
-	lrrbot.vote_update = respond_to, game
-	vote_respond(lrrbot, conn, respond_to, game)
+	show_id = lrrbot.get_show_id()
+	with lrrbot.engine.begin() as pg_conn:
+		pg_conn.execute("""
+			INSERT INTO game_votes (
+				game_id,
+				show_id,
+				user_id,
+				vote
+			) VALUES (
+				%(game_id)s,
+				%(show_id)s,
+				%(user_id)s,
+				%(vote)s
+			) ON CONFLICT (game_id, show_id, user_id) DO UPDATE SET
+				vote = EXCLUDED.vote
+		""", {
+			"game_id": game_id,
+			"show_id": show_id,
+			"user_id": event.tags["user-id"],
+			"vote": vote_good is not None,
+		})
+	lrrbot.vote_update = respond_to, game_id
+	vote_respond(lrrbot, conn, respond_to, game_id)
 
 @utils.cache(60)
-def vote_respond(lrrbot, conn, respond_to, game):
-	if game and game.get("votes"):
-		good = sum(game["votes"].values())
-		count = len(game["votes"])
-		show = lrrbot.show_override or lrrbot.show
+def vote_respond(lrrbot, conn, respond_to, game_id):
+	if game_id is not None:
+		show_id = lrrbot.get_show_id()
 
-		conn.privmsg(respond_to, "Rating for %s on %s is now %.0f%% (%d/%d)" % (game_name(game), show_name(show), 100*good/count, good, count))
+		game_votes = lrrbot.metadata.tables["game_votes"]
+		game_per_show_data = lrrbot.metadata.tables["game_per_show_data"]
+		games = lrrbot.metadata.tables["games"]
+		shows = lrrbot.metadata.tables["shows"]
+		with lrrbot.engine.begin() as pg_conn:
+			good = sqlalchemy.cast(
+				sqlalchemy.func.sum(sqlalchemy.cast(game_votes.c.vote, sqlalchemy.Integer)),
+				sqlalchemy.Numeric
+			)
+			votes_query = sqlalchemy.alias(sqlalchemy.select([
+				(100 * good / sqlalchemy.func.count(game_votes.c.vote)).label("rating"),
+				good.label("good"),
+				sqlalchemy.func.count(game_votes.c.vote).label("total"),
+			]).where(game_votes.c.game_id == game_id).where(game_votes.c.show_id == show_id))
+			game, show, rating, good, total = pg_conn.execute(
+				sqlalchemy.select([
+					sqlalchemy.func.coalesce(game_per_show_data.c.display_name, games.c.name),
+					shows.c.name,
+					votes_query.c.rating,
+					votes_query.c.good,
+					votes_query.c.total,
+				]).select_from(
+					games.outerjoin(game_per_show_data,
+						(game_per_show_data.c.game_id == games.c.id)
+							& (game_per_show_data.c.show_id == show_id))
+				).where(games.c.id == game_id).where(shows.c.id == show_id)).first()
+		conn.privmsg(respond_to, "Rating for %s on %s is now %0.0f%% (%d/%d)" % (game, show, rating, good, total))
 	lrrbot.vote_update = None
 
 @bot.command("game display (.*?)")
@@ -75,13 +135,34 @@ def set_game_name(lrrbot, conn, event, respond_to, name):
 
 	Change the display name of the current game to NAME.
 	"""
-	game = lrrbot.get_current_game(readonly=False)
-	if game is None:
-		conn.privmsg(respond_to, "Not currently playing any game, if they are yell at them to update the stream")
+	game_id = lrrbot.get_game_id()
+	if game_id is None:
+		conn.privmsg(respond_to, "Not currently playing any game.")
 		return
-	game["display"] = name
-	storage.save()
-	conn.privmsg(respond_to, "OK, I'll start calling %(name)s \"%(display)s\"" % game)
+	show_id = lrrbot.get_show_id()
+
+	games = lrrbot.metadata.tables["games"]
+	game_per_show_data = lrrbot.metadata.tables["game_per_show_data"]
+	with lrrbot.engine.begin() as pg_conn:
+		real_name, = pg_conn.execute(sqlalchemy.select([games.c.name]).where(games.c.id == game_id)).first()
+		pg_conn.execute("""
+			INSERT INTO game_per_show_data (
+				game_id,
+				show_id,
+				display_name
+			) VALUES (
+				%(game_id)s,
+				%(show_id)s,
+				%(display_name)s
+			) ON CONFLICT (game_id, show_id) DO UPDATE SET
+				display_name = EXCLUDED.display_name
+		""", {
+			"game_id": game_id,
+			"show_id": show_id,
+			"display_name": name if real_name != name else None,
+		})
+
+		conn.privmsg(respond_to, "OK, I'll start calling %s \"%s\"" % (real_name, name))
 
 @bot.command("game override (.*?)")
 @lrrbot.decorators.mod_only
@@ -102,19 +183,30 @@ def override_game(lrrbot, conn, event, respond_to, game):
 	Should the crew start regularly playing a game called "off", I'm sure we'll figure something out.
 	"""
 	if game == "" or game.lower() == "off":
-		lrrbot.game_override = None
+		lrrbot.override_game(None)
 		operation = "disabled"
 	else:
-		lrrbot.game_override = game
+		lrrbot.override_game(game)
 		operation = "enabled"
 	twitch.get_info.reset_throttle()
 	current_game.reset_throttle()
-	game = lrrbot.get_current_game()
+	game_id = lrrbot.get_game_id()
+	show_id = lrrbot.get_show_id()
 	message = "Override %s. " % operation
-	if game is None:
+	if game_id is None:
 		message += "Not currently playing any game"
 	else:
-		message += "Currently playing: %s" % game_name(game)
+		games = lrrbot.metadata.tables["games"]
+		game_per_show_data = lrrbot.metadata.tables["game_per_show_data"]
+		with lrrbot.engine.begin() as pg_conn:
+			name, = pg_conn.execute(sqlalchemy.select([games.c.name])
+				.select_from(
+					games
+						.outerjoin(game_per_show_data,
+							(games.c.id == game_per_show_data.c.game_id) & (game_per_show_data.c.show_id == show_id)
+						)
+				).where(games.c.id == game_id)).first()
+		message += "Currently playing: %s" % name
 	conn.privmsg(respond_to, message)
 
 @bot.command("game refresh")
@@ -131,7 +223,6 @@ def refresh(lrrbot, conn, event, respond_to):
 	current_game(lrrbot, conn, event, respond_to)
 
 @bot.command("game completed")
-@lrrbot.decorators.mod_only
 @lrrbot.decorators.throttle(30, notify=lrrbot.decorators.Visibility.PUBLIC, modoverride=False, allowprivate=False)
 def completed(lrrbot, conn, event, respond_to):
 	"""
@@ -140,14 +231,24 @@ def completed(lrrbot, conn, event, respond_to):
 
 	Mark a game as having been completed.
 	"""
-	game = lrrbot.get_current_game(readonly=False)
-	if game is None:
+	game_id = lrrbot.get_game_id()
+	if game_id is None:
 		conn.privmsg(respond_to, "Not currently playing any game")
 		return
-	game.setdefault("stats", {}).setdefault("completed", 0)
-	game["stats"]["completed"] += 1
-	storage.save()
-	emote = storage.data.get('stats', {}).get('completed', {}).get('emote', "")
+	show_id = lrrbot.get_show_id()
+	games = lrrbot.metadata.tables["games"]
+	game_per_show_data = lrrbot.metadata.tables["game_per_show_data"]
+	stats = lrrbot.metadata.tables["stats"]
+	with lrrbot.engine.begin() as pg_conn:
+		name, = pg_conn.execute(sqlalchemy.select([
+			sqlalchemy.func.coalesce(game_per_show_data.c.display_name, games.c.name),
+		]).select_from(games.outerjoin(
+			game_per_show_data,
+			(game_per_show_data.c.game_id == games.c.id) & (game_per_show_data.c.show_id == show_id)
+		)).where(games.c.id == game_id)).first()
+		stat_id, emote = pg_conn.execute(sqlalchemy.select([stats.c.id, stats.c.emote])
+			.where(stats.c.string_id == "completed")).first()
+		stat_increment(lrrbot, pg_conn, game_id, show_id, stat_id, 1)
 	if emote:
 		emote += " "
-	conn.privmsg(respond_to, "%s%s added to the completed list" % (emote, game_name(game)))
+	conn.privmsg(respond_to, "%s%s added to the completed list" % (emote, name))

--- a/lrrbot/storage.py
+++ b/lrrbot/storage.py
@@ -8,25 +8,6 @@ from common.config import config
 Data structure:
 
 data = {
-	'stats': { # Different statistics that are tracked
-		'<stat-name>': { # the name as used in commands
-			'singular': '<stat-name>', # For display - defaults to the same as the command
-			'plural': '<stat-names>', # For display
-		},
-	},
-	'shows': { # Shows we have tracked stats for
-		'<id>': { # Show ID or '' for unknown show
-			'name': '<name>', # Name of this show
-			'games': { # Games we have tracked stats for
-				<id>: { # id is the Twitch game ID, or the game name for non-Twitch override games
-				'name': '<name>', # Official game name as Twitch recognises it - to aid matching
-				'display': '<display name>' # Display name, defaults to the same as name. For games with LRL nicknames
-				'stats': {
-					'<stat-name>': <count>,
-				},
-			},
-		},
-	},
 	'spam_rules': [
 		{
 			're': '<regular expression>',
@@ -37,23 +18,6 @@ data = {
 
 For example:
 data = {
-	'stats': {
-		'death': {'plural': "deaths"},
-	},
-	'shows': {
-		'': {
-			'name': "Unknown",
-			'games': {
-				12345: {
-					'name': "Example game",
-					'display': "Funny name for example game",
-					'stats': {
-						'death': 17,
-					},
-				},
-			},
-		},
-	},
 	'spam_rules': [
 		{
 			're': '^I am a spambot!$',
@@ -81,62 +45,5 @@ def save():
 
 	os.rename(realfile, backupfile)
 	os.rename(tempfile, realfile)
-
-def find_game(show, game, readonly):
-	"""
-	Look up a game by ID or by name, and keep game data up-to-date if names
-	or IDs change in Twitch's database.
-	"""
-	if game is None:
-		return None
-
-	maybe_immutable = utils.immutable if readonly else lambda x:x
-
-	# Allow this to be called with just a string, for simplicity
-	if isinstance(game, str):
-		game = {'_id': game, 'name': game, 'is_override': True}
-
-	games = data.setdefault('shows', {}).setdefault(show, {"name":show}).setdefault('games', {})
-
-	# First try to find the game using the Twitch ID
-	if str(game['_id']) in games:
-		gamedata = games[str(game['_id'])]
-		# Check if the name has changed
-		if gamedata['name'] != game['name']:
-			gamedata['name'] = game['name']
-			save()
-		gamedata['id'] = str(game['_id'])
-		return maybe_immutable(gamedata)
-
-	# Next try to find the game using the name
-	for gameid, gamedata in games.items():
-		if gamedata['name'] == game['name']:
-			# If this is from Twitch, fix the ID
-			if not game.get('is_override'):
-				del games[gameid]
-				games[str(game['_id'])] = gamedata
-				gamedata['id'] = str(game['_id'])
-				save()
-			else:
-				gamedata['id'] = gameid
-			return maybe_immutable(gamedata)
-
-	# Look up the game by display name as a fallback
-	for gameid, gamedata in games.items():
-		if 'display' in gamedata and gamedata['display'] == game['name']:
-			# Don't try to keep things aligned here...
-			gamedata['id'] = gameid
-			return maybe_immutable(gamedata)
-
-	# This is a new game
-	gamedata = {
-		'id': str(game['_id']),
-		'name': game['name'],
-		'stats': {},
-	}
-	if not readonly:
-		games[str(game['_id'])] = gamedata
-		save()
-	return maybe_immutable(gamedata)
 
 load()

--- a/www/api.py
+++ b/www/api.py
@@ -1,3 +1,4 @@
+import sqlalchemy
 from www import server
 from www import botinteract
 from www import login
@@ -6,13 +7,25 @@ import datetime
 
 @server.app.route("/api/stats/<stat>")
 def api_stats(stat):
-	game_id = botinteract.get_current_game()
+	game_id = botinteract.get_game_id()
 	if game_id is None:
 		return "-"
-	show = botinteract.get_show()
-	count = botinteract.get_data(["shows", show, "games", game_id, "stats", stat])
-	if not count:
-		count = 0
+	show_id = botinteract.get_show_id()
+
+	game_stats = server.db.metadata.tables["game_stats"]
+	stats = server.db.metadata.tables["stats"]
+	with server.db.engine.begin() as conn:
+		count = conn.execute(sqlalchemy.select([game_stats.c.count])
+			.where(game_stats.c.game_id == game_id)
+			.where(game_stats.c.show_id == show_id)
+			.where(game_stats.c.stat_id == sqlalchemy.select([stats.c.id])
+				.where(stats.c.string_id == stat))
+		).first()
+		if count is not None:
+			count, = count
+		else:
+			count = 0
+
 	return str(count)
 
 @server.app.route("/api/stormcount")
@@ -29,14 +42,26 @@ def nextstream():
 
 @server.app.route("/api/votes")
 def api_votes():
-	game_id = botinteract.get_current_game()
+	game_id = botinteract.get_game_id()
 	if game_id is None:
 		return "-"
-	show = botinteract.get_show()
-	data = botinteract.get_data(["shows", show, "games", game_id, "votes"])
-	count = len(data)
-	good = sum(data.values())
-	return "%.0f%% (%d/%d)" % (100*good/count, good, count)
+	show_id = botinteract.get_show_id()
+
+	game_votes = server.db.metadata.tables["game_votes"]
+	with server.db.engine.begin() as conn:
+		good = sqlalchemy.cast(
+			sqlalchemy.func.sum(sqlalchemy.cast(game_votes.c.vote, sqlalchemy.Integer)),
+			sqlalchemy.Numeric
+		)
+		rating = conn.execute(sqlalchemy.select([
+			(100 * good / sqlalchemy.func.count(game_votes.c.vote)),
+			good,
+			sqlalchemy.func.count(game_votes.c.vote),
+		]).where(game_votes.c.game_id == game_id).where(game_votes.c.show_id == show_id)).first()
+		if rating is not None:
+			return "%.0f%% (%d/%d)" % (float(rating[0]), rating[1], rating[2])
+		else:
+			return "-% (0/0)"
 
 @server.app.route("/api/show/<show>")
 @login.with_minimal_session
@@ -52,11 +77,23 @@ def set_show(session, show):
 
 @server.app.route("/api/game")
 def get_game():
-	return botinteract.get_current_game_name() or "-"
+	game_id = botinteract.get_game_id()
+	if game_id is None:
+		return "-"
+	show_id = botinteract.get_show_id()
+
+	games = server.db.metadata.tables["games"]
+	with server.db.engine.begin() as conn:
+		return conn.execute(sqlalchemy.select([games.c.name]).where(games.c.id == game_id)).first()[0]
 
 @server.app.route("/api/show")
 def get_show():
-	return botinteract.get_show() or "-"
+	show_id = botinteract.get_show_id()
+
+	shows = server.db.metadata.tables["shows"]
+	with server.db.engine.begin() as conn:
+		show, = conn.execute(sqlalchemy.select([shows.c.string_id]).where(shows.c.id == show_id)).first()
+		return show or "-"
 
 @server.app.route("/api/tweet")
 @login.with_minimal_session

--- a/www/botinteract.py
+++ b/www/botinteract.py
@@ -34,11 +34,11 @@ def send_bot_command(command, param, timeout=5, session=None):
 	else:
 		raise APIError("Server error in %s:\n%s" % (command, result['result']))
 
-def get_current_game():
-	return send_bot_command("current_game", None)
+def get_game_id():
+	return send_bot_command("get_game_id", None)
 
-def get_current_game_name():
-	return send_bot_command("current_game_name", None)
+def get_show_id():
+	return send_bot_command("get_show_id", None)
 
 def get_data(key):
 	return send_bot_command("get_data", {
@@ -88,9 +88,6 @@ def nextstream():
 
 def set_show(show):
 	return send_bot_command("set_show", {'show': show})
-
-def get_show():
-	return send_bot_command("get_show", None)
 
 def get_tweet():
 	return send_bot_command("get_tweet", None)

--- a/www/login.py
+++ b/www/login.py
@@ -13,6 +13,7 @@ from www import server
 from common.config import config, from_apipass
 from common import utils
 from common import twitch
+from common import game_data
 
 with server.db.engine.begin() as conn:
 	from_apipass = {
@@ -151,6 +152,62 @@ def load_session(include_url=True, include_header=True):
 		session['url'] = None
 	if include_header:
 		session['header'] = botinteract.get_header_info()
+		if 'current_game' in session['header']:
+			games = server.db.metadata.tables["games"]
+			shows = server.db.metadata.tables["shows"]
+			stats = server.db.metadata.tables["stats"]
+			game_per_show_data = server.db.metadata.tables["game_per_show_data"]
+			game_stats = server.db.metadata.tables["game_stats"]
+			game_votes = server.db.metadata.tables["game_votes"]
+			disabled_stats = server.db.metadata.tables["disabled_stats"]
+			with server.db.engine.begin() as conn:
+				game_id = session['header']['current_game']['id']
+				show_id = session['header']['current_show']['id']
+				session['header']['current_game']['display'], = conn.execute(sqlalchemy.select([
+					sqlalchemy.func.coalesce(game_per_show_data.c.display_name, games.c.name),
+				]).select_from(games
+					.outerjoin(game_per_show_data, (game_per_show_data.c.game_id == games.c.id) & (game_per_show_data.c.show_id == show_id))
+				).where(games.c.id == game_id)).first()
+
+				session['header']['current_show']['name'], = conn.execute(sqlalchemy.select([
+					shows.c.name,
+				]).where(shows.c.id == show_id)).first()
+
+				good = sqlalchemy.cast(
+					sqlalchemy.func.sum(sqlalchemy.cast(game_votes.c.vote, sqlalchemy.Integer)),
+					sqlalchemy.Numeric
+				)
+				rating = conn.execute(sqlalchemy.select([
+					(100 * good / sqlalchemy.func.count(game_votes.c.vote)),
+					good,
+					sqlalchemy.func.count(game_votes.c.vote),
+				]).where(game_votes.c.game_id == game_id).where(game_votes.c.show_id == show_id)).first()
+				if rating is not None:
+					session['header']['current_game']["rating"] = {
+						'perc': rating[0],
+						'good': rating[1],
+						'total': rating[2],
+					}
+				stats_query = sqlalchemy.select([
+					game_stats.c.count,
+					game_data.stat_plural(stats, game_stats.c.count)
+				]).select_from(game_stats
+					.join(stats, stats.c.id == game_stats.c.stat_id)
+				).where(game_stats.c.game_id == game_id) \
+					.where(game_stats.c.show_id == show_id) \
+					.where(~sqlalchemy.exists(sqlalchemy.select([1])
+						.where(disabled_stats.c.stat_id == game_stats.c.stat_id)
+						.where(disabled_stats.c.show_id == game_stats.c.show_id)
+					)) \
+					.order_by(game_stats.c.count.desc())
+				session['header']['current_game']['stats'] = [
+					{
+						'count': count,
+						'type': type,
+					}
+					for count, type in conn.execute(stats_query)
+				]
+
 	if user_id is not None:
 		users = server.db.metadata.tables["users"]
 		with server.db.engine.begin() as conn:

--- a/www/static/style.css
+++ b/www/static/style.css
@@ -600,3 +600,7 @@ table.quote-search input,
 table.quote-search select {
 	width: 100%
 }
+
+.stat.disabled {
+	color: #999999;
+}

--- a/www/stats.py
+++ b/www/stats.py
@@ -1,76 +1,227 @@
 import flask
 import flask.json
+import sqlalchemy
+from common import game_data
 from www import server
 from www import login
 from www import botinteract
 
+import time
+
 @server.app.route('/stats')
 @login.with_session
 def stats(session):
-	show_id = flask.request.values.get("show")
-	shows = botinteract.get_data(["shows"])
-	if show_id is not None:
-		show_id = show_id.lower()
-		entries = shows.get(show_id, {}).get("games", {})
-		for game in entries.values():
-			game["show_id"] = show_id
-	else:
-		entries = {}
-		for show_id, show in shows.items():
-			show_name = show.get("name", show_id)
-			entry = {
-				"id": show_id,
-				"name": show_name,
-				"stats": {
-				},
-			}
-			for game in show['games'].values():
-				for stat, value in game['stats'].items():
-					try:
-						entry["stats"][stat] += value
-					except KeyError:
-						entry["stats"][stat] = value
-			entries[show_id] = entry
-		show_id = None
-	shows = [{"name": show.get("name", name), "id": name} for name, show in shows.items()]
-	shows = sorted(shows, key=lambda show: show["name"].lower())
-	stats = botinteract.get_data(["stats"])
-	# Calculate totals
-	for statkey, stat in stats.items():
-		stat['total'] = sum(g.get('stats',{}).get(statkey,0) for g in entries.values())
-	# Make our lives easier in the template - make sure all our defaults exist, and turn our major dicts into lists
-	for gamekey, game in entries.items():
-		game.setdefault('display', game['name'])
-		game.setdefault('stats', {})
-		for statkey in stats.keys():
-			game['stats'].setdefault(statkey, 0)
-		game.setdefault('gamekey', gamekey)
-		game.setdefault('votes', {})
-		game['votecount'] = len(game['votes'])
-		game['votegood'] = sum(game['votes'].values())
-		if game['votecount']:
-			game['voteperc'] = 100.0 * game['votegood'] / game['votecount']
-		else:
-			game['voteperc'] = 0.0
-	for statkey, stat in stats.items():
-		stat.setdefault('singular', statkey)
-		stat.setdefault('statkey', statkey)
-	entries = list(entries.values())
-	entries.sort(key=lambda g: g['display'].upper())
-	if show_id is not None:
-		votegames = [g for g in entries if g['votecount']]
-		votegames.sort(key=lambda g: -g['voteperc'])
-	else:
-		votegames = None
-	stats = list(stats.values())
-	stats.sort(key=lambda s: -s['total'])
-	# Calculate graph datasets
-	for stat in stats:
-		stat['graphdata'] = [
-			(game["display"], game['stats'][stat['statkey']])
-			for game in entries
-			if game['stats'][stat['statkey']]
-		]
-		stat['graphdata'].sort(key=lambda pt:-pt[1])
+	shows = server.db.metadata.tables["shows"]
+	stats = server.db.metadata.tables["stats"]
+	game_stats = server.db.metadata.tables["game_stats"]
+	game_per_show_data = server.db.metadata.tables["game_per_show_data"]
+	games = server.db.metadata.tables["games"]
+	game_votes = server.db.metadata.tables["game_votes"]
+	disabled_stats = server.db.metadata.tables["disabled_stats"]
 
-	return flask.render_template('stats.html', entries=entries, votegames=votegames, stats=stats, session=session, shows=shows, show_id=show_id)
+	string_id = flask.request.values.get("show")
+	if string_id is not None:
+		with server.db.engine.begin() as conn:
+			id = conn.execute(sqlalchemy.select([shows.c.id]).where(shows.c.string_id == string_id)).first()
+			if id is None:
+				return flask.redirect(flask.url_for("stats"))
+			else:
+				return flask.redirect(flask.url_for("stats", id=id[0]), 301)
+
+	show_id = flask.request.values.get("id")
+	with server.db.engine.begin() as conn:
+		shows_query = sqlalchemy.select([shows.c.id, shows.c.name]).order_by(shows.c.name)
+
+		if show_id is None:
+			graphdata_query = sqlalchemy.select([
+				sqlalchemy.func.jsonb_build_array(shows.c.name, sqlalchemy.func.sum(game_stats.c.count))
+			]).select_from(game_stats.join(shows, game_stats.c.show_id == shows.c.id)) \
+				.where(game_stats.c.stat_id == stats.c.id) \
+				.order_by(sqlalchemy.func.sum(game_stats.c.count).desc()) \
+				.group_by(shows.c.name)
+
+			votegames_query = None
+
+			entries_subquery = sqlalchemy.alias(sqlalchemy.select([
+				game_stats.c.show_id,
+				game_stats.c.stat_id,
+				sqlalchemy.func.sum(game_stats.c.count).label("count"),
+			]).group_by(game_stats.c.show_id, game_stats.c.stat_id))
+
+			entries_query = sqlalchemy.select([
+				shows.c.id,
+				shows.c.name,
+				shows.c.name.concat(""), # SQLAlchemy removes duplicate columns
+				entries_subquery.c.stat_id,
+				entries_subquery.c.count,
+				sqlalchemy.exists(sqlalchemy.select([1])
+					.where(disabled_stats.c.show_id == shows.c.id)
+					.where(disabled_stats.c.stat_id == entries_subquery.c.stat_id)
+				).label("disabled"),
+			]).select_from(entries_subquery
+				.join(shows, shows.c.id == entries_subquery.c.show_id))
+
+			missing_entries_query = None
+		else:
+			show_id = int(show_id)
+
+			graphdata_query = sqlalchemy.select([
+				sqlalchemy.func.jsonb_build_array(
+					sqlalchemy.func.coalesce(game_per_show_data.c.display_name, games.c.name),
+					game_stats.c.count,
+				)
+			]).select_from(
+				game_stats
+					.join(games, games.c.id == game_stats.c.game_id)
+					.outerjoin(game_per_show_data, (game_per_show_data.c.game_id == game_stats.c.game_id) & (game_per_show_data.c.show_id == show_id))
+			) \
+				.where(game_stats.c.show_id == show_id) \
+				.where(game_stats.c.stat_id == stats.c.id) \
+				.where(game_stats.c.count > 0) \
+				.order_by(game_stats.c.count.desc())
+
+			votegood = sqlalchemy.cast(
+				sqlalchemy.func.sum(sqlalchemy.cast(game_votes.c.vote, sqlalchemy.Integer)),
+				sqlalchemy.Numeric
+			)
+			ratings = sqlalchemy.alias(sqlalchemy.select([
+				game_votes.c.game_id,
+				votegood.label("votegood"),
+				sqlalchemy.func.count(game_votes.c.vote).label("votecount"),
+				(100 * votegood / sqlalchemy.func.count(game_votes.c.vote)).label("voteperc")
+			]).where(game_votes.c.show_id == show_id).group_by(game_votes.c.game_id))
+
+			votegames_query = sqlalchemy.select([
+				games.c.name,
+				sqlalchemy.func.coalesce(game_per_show_data.c.display_name, games.c.name),
+				ratings.c.votegood,
+				ratings.c.votecount,
+				ratings.c.voteperc,
+			]).select_from(ratings
+				.join(games, games.c.id == ratings.c.game_id)
+				.outerjoin(game_per_show_data, (game_per_show_data.c.game_id == ratings.c.game_id) & (game_per_show_data.c.show_id == show_id))
+			).order_by(ratings.c.voteperc.desc())
+
+			entries_query = sqlalchemy.select([
+				games.c.id,
+				games.c.name,
+				sqlalchemy.func.coalesce(game_per_show_data.c.display_name, games.c.name),
+				game_stats.c.stat_id,
+				game_stats.c.count,
+				sqlalchemy.exists(sqlalchemy.select([1])
+					.where(disabled_stats.c.show_id == show_id)
+					.where(disabled_stats.c.stat_id == game_stats.c.stat_id)
+				).label("disabled"),
+			]).select_from(game_stats
+				.join(games, games.c.id == game_stats.c.game_id)
+				.outerjoin(game_per_show_data, (game_per_show_data.c.game_id == game_stats.c.game_id) & (game_per_show_data.c.show_id == show_id))
+			).where(game_stats.c.show_id == show_id)
+
+			missing_entries_query = sqlalchemy.select([
+				games.c.id,
+				games.c.name,
+				sqlalchemy.func.coalesce(game_per_show_data.c.display_name, games.c.name),
+			], distinct=True).select_from(game_votes
+				.join(games, games.c.id == game_votes.c.game_id)
+				.outerjoin(game_per_show_data, (game_per_show_data.c.game_id == game_votes.c.game_id) & (game_per_show_data.c.show_id == show_id))
+			).where(game_votes.c.show_id == show_id) \
+				.where(~sqlalchemy.exists(sqlalchemy.select([1]))
+					.where(game_stats.c.game_id == game_votes.c.game_id)
+					.where(game_stats.c.show_id == show_id)
+				)
+
+		stats_query = sqlalchemy.select([
+			stats.c.id, game_data.stat_plural(stats, None),
+			sqlalchemy.func.array(graphdata_query.as_scalar())
+		])
+
+		entries_query = sqlalchemy.alias(entries_query)
+		totals_query = sqlalchemy.select([
+			entries_query.c.stat_id,
+			sqlalchemy.func.sum(entries_query.c.count),
+			sqlalchemy.func.bool_and(entries_query.c.disabled),
+		]).group_by(entries_query.c.stat_id)
+
+		if show_id is None:
+			# TODO: if stat is disabled on all shows, sort it to the right like on per-show pages.
+			stats_query = stats_query.order_by(
+				sqlalchemy.func.coalesce(
+					sqlalchemy.select([sqlalchemy.func.sum(game_stats.c.count)])
+						.where(game_stats.c.stat_id == stats.c.id)
+						.as_scalar(),
+					0
+				).desc()
+			)
+		else:
+			stats_query = stats_query.order_by(
+				sqlalchemy.exists(sqlalchemy.select([1])
+					.where(disabled_stats.c.show_id == show_id)
+					.where(disabled_stats.c.stat_id == stats.c.id)
+				),
+				sqlalchemy.func.coalesce(
+					sqlalchemy.select([sqlalchemy.func.sum(game_stats.c.count)])
+						.where(game_stats.c.stat_id == stats.c.id)
+						.where(game_stats.c.show_id == show_id)
+						.as_scalar(),
+					0
+				).desc(),
+			)
+
+		stats = [
+			{
+				"statkey": id,
+				"plural": plural,
+				"graphdata": graphdata,
+			}
+			for id, plural, graphdata in conn.execute(stats_query)
+		]
+
+		all_shows = [
+			{
+				"id": id,
+				"name": name,
+			}
+			for id, name in conn.execute(shows_query)
+		]
+		if votegames_query is not None:
+			votegames = [
+				{
+					"name": name,
+					"display": display_name,
+					"voteperc": voteperc,
+					"votegood": votegood,
+					"votecount": votecount,
+				}
+				for name, display_name, votegood, votecount, voteperc in conn.execute(votegames_query)
+			]
+		else:
+			votegames = None
+
+		entries = {}
+		for id, name, display, stat, count, disabled in conn.execute(entries_query):
+			try:
+				entries[id]['stats'][stat] = (count, disabled)
+			except KeyError:
+				entries[id] = {
+					'name': name,
+					'display': display,
+					'stats': {
+						stat: (count, disabled)
+					}
+				}
+		if missing_entries_query is not None:
+			for id, name, display in conn.execute(missing_entries_query):
+				assert id not in entries
+				entries[id] = {
+					'name': name,
+					'display': display,
+					'stats': {}
+				}
+		entries = list(entries.values())
+
+		totals = {
+			id: (count, disabled)
+			for id, count, disabled in conn.execute(totals_query)
+		}
+
+	return flask.render_template('stats.html', entries=entries, votegames=votegames, stats=stats, session=session, shows=all_shows, show_id=show_id, totals=totals)

--- a/www/templates/stats.html
+++ b/www/templates/stats.html
@@ -19,7 +19,7 @@
         {%if show_id == show['id']%}
         <strong>{{show['name']|e}}</strong>
         {%else%}
-        <a href="{{url_for('stats')|e}}?show={{show['id']|urlencode|e}}">{{show['name']|e}}</a>
+        <a href="{{url_for('stats')|e}}?id={{show['id']|e}}">{{show['name']|e}}</a>
         {%endif%}
     </li>
     {%endfor%}
@@ -29,7 +29,7 @@
 <tr>
 	<th class="game">{%if show_id is none%}Show{%else%}Game{%endif%}</th>
 	{%for stat in stats%}
-		<th class="stat {{stat['statkey']|e}}">{{stat['plural']|ucfirst|e}}</th>
+		<th class="stat{%if totals.get(stat['statkey'], (0, False))[1]%} disabled{%endif%}">{{stat['plural']|ucfirst|e}}</th>
 	{%endfor%}
 </tr>
 </thead>
@@ -42,10 +42,11 @@
 			{%else%}
 				{{entry['display']|e}}
 			{%endif%}
-			{%if 'show' in entry%}({{entry['show']|e}}){%endif%}
 		</td>
 		{%for stat in stats%}
-			<td class="stat {{stat['statkey']|e}}">{{entry['stats'][stat['statkey']]|e}}</td>
+			<td class="stat{%if entry['stats'].get(stat['statkey'], (0, totals.get(stat['statkey'], (0, False))[1]))[1]%} disabled{%endif%}">
+                {{entry['stats'].get(stat['statkey'], (0, False))[0]|e}}
+            </td>
 		{%endfor%}
 	</tr>
 {%endfor%}
@@ -54,7 +55,9 @@
 <tr>
 	<th class="total">Total</th>
 	{%for stat in stats%}
-		<th class="stat {{stat['statkey']|e}}">{{stat['total']|e}}</th>
+		<th class="stat{%if totals.get(stat['statkey'], (0, False))[1]%} disabled{%endif%}">
+            {{totals.get(stat['statkey'], (0, False))[0]|e}}
+        </th>
 	{%endfor%}
 </tr>
 </tfoot>
@@ -91,7 +94,6 @@ $(document).ready(function() {
 				{%if game['display'] != game['name']%}<span class="alias" title="{{game['name']|e}}">{%endif%}
 				{{game['display']|e}}
 				{%if game['display'] != game['name']%}</span>{%endif%}
-				{%if 'show' in game%}({{game['show']|e}}){%endif%}
 			</td>
 			<td class="rating graph">
 				<div class="rating">


### PR DESCRIPTION
There are a lot of things wrong with this code: no query optimisation work has been done: the queries do multiple passes over the same data and there are no indexes, there are no management interfaces and tables have awkward names. Since this is a huge changeset I want to merge this before it bitrots too heavily.

I changed `!complete` and `!game complete` to no longer be mod-only.

Added the option to disable stats. Disabled stats can't be incremented with `!<stat>` and are de-emphasised or in some cases hidden on the website. The migration script automatically disables deaths, paves and tilts on A Swiftly Tilting Cameron.

For #89. For #83. Closes #184.