### PR TITLE
Add a proper logging conf file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
-*.conf
+lrrbot.conf
 *.log
+*.log.*
 *.pyc
 __pycache__
 *~

--- a/common/config.py
+++ b/common/config.py
@@ -1,5 +1,4 @@
 import configparser
-import logging
 import re
 
 import pytz
@@ -46,17 +45,6 @@ config['checksubstime'] = int(config.get('checksubstime', 60))
 # debug - boolean option
 config.setdefault('debug', False)
 config['debug'] = str(config['debug']).lower() != 'false'
-# loglevel - either a number or a level name, default depends on debug setting
-try:
-	config['loglevel'] = int(config.get('loglevel', logging.DEBUG if config['debug'] else logging.INFO))
-except ValueError:
-	config['loglevel'] = logging.getLevelName(config['loglevel'])
-	# This assert fails if the entered value is neither a number nor a recognised level name
-	assert isinstance(config['loglevel'], int)
-# logfile - either blank a filename to log to, or blank to indicate logging to stderr only
-config.setdefault('logfile', None)
-if config['logfile'] == "":
-	config['logfile'] = None
 
 # notifyuser - user to watch for notifications
 config['notifyuser'] = config.get('notifyuser', 'twitchnotify').lower()

--- a/common/utils.py
+++ b/common/utils.py
@@ -10,6 +10,8 @@ import socket
 import textwrap
 import time
 import heapq
+import logging.config
+import configparser
 
 import werkzeug.datastructures
 
@@ -348,3 +350,29 @@ def counter(n=6):
 	for _ in range(n):
 		s += chr(random.randint(*random.choice(COUNTER_RANGES)))
 	return s
+
+def merge_config_section(configs, prefix):
+	"""
+	Merge prefixed sections into the real sections, so that different values can
+	be set to apply to different modes.
+
+	eg:
+	merge_config_section(configs, "debug")
+	will merge [debug_xyz] sections into [xyz] sections
+	"""
+	prefix = prefix + "_"
+	for section in configs.sections():
+		if section[:len(prefix)] == prefix:
+			if not configs.has_section(section[len(prefix):]):
+				configs.add_section(section[len(prefix):])
+			for option, value in configs.items(section):
+				configs.set(section[len(prefix):], option, value)
+
+def init_logging(mode=None):
+	logging_conf = configparser.ConfigParser()
+	logging_conf.read("logging.conf")
+	if config.config['debug']:
+		merge_config_section(logging_conf, "debug")
+	if mode:
+		merge_config_section(logging_conf, mode)
+	logging.config.fileConfig(logging_conf)

--- a/common/utils.py
+++ b/common/utils.py
@@ -369,6 +369,7 @@ def merge_config_section(configs, prefix):
 				configs.set(section[len(prefix):], option, value)
 
 def init_logging(mode=None):
+	logging.Formatter.converter = time.gmtime
 	logging_conf = configparser.ConfigParser()
 	logging_conf.read("logging.conf")
 	if config.config['debug']:

--- a/logging.conf
+++ b/logging.conf
@@ -3,6 +3,8 @@ keys=root,requests
 
 [logger_root]
 level=NOTSET
+handlers=main,debug
+[debug_lrrbot_logger_root]
 handlers=main,debug,stdout
 
 [logger_requests]
@@ -19,14 +21,20 @@ class=handlers.TimedRotatingFileHandler
 level=INFO
 formatter=main
 # Rotate every week, on Saturday morning midnight
+[lrrbot_handler_main]
 args=('lrrbot.log', 'W5', 1, 0, 'utf-8', False, True)
+[webserver_handler_main]
+args=('webserver.log', 'W5', 1, 0, 'utf-8', False, True)
 
 [handler_debug]
 class=handlers.TimedRotatingFileHandler
 level=NOTSET
 formatter=main
 # Rotate daily, and only keep a week of history
+[lrrbot_handler_debug]
 args=('lrrbot.debug.log', 'MIDNIGHT', 1, 7, 'utf-8', False, True)
+[webserver_handler_debug]
+args=('webserver.debug.log', 'MIDNIGHT', 1, 7, 'utf-8', False, True)
 
 [handler_stdout]
 class=StreamHandler

--- a/logging.conf
+++ b/logging.conf
@@ -1,0 +1,42 @@
+[loggers]
+keys=root,requests
+
+[logger_root]
+level=NOTSET
+handlers=main,debug,stdout
+
+[logger_requests]
+level=ERROR
+propagate=1
+qualname=requests
+handlers=
+
+[handlers]
+keys=main,debug,stdout
+
+[handler_main]
+class=handlers.TimedRotatingFileHandler
+level=INFO
+formatter=main
+# Rotate every week, on Saturday morning midnight
+args=('lrrbot.log', 'W5', 1, 0, 'utf-8', False, True)
+
+[handler_debug]
+class=handlers.TimedRotatingFileHandler
+level=NOTSET
+formatter=main
+# Rotate daily, and only keep a week of history
+args=('lrrbot.debug.log', 'MIDNIGHT', 1, 7, 'utf-8', False, True)
+
+[handler_stdout]
+class=StreamHandler
+level=NOTSET
+formatter=main
+args=(sys.stdout,)
+
+[formatters]
+keys=main
+
+[formatter_main]
+class=logging.Formatter
+format=[%(asctime)s] %(levelname)s:%(name)s:%(message)s

--- a/start_bot.py
+++ b/start_bot.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 
-import logging, logging.config
-from common.config import config
+import logging
+from common import utils
 
-logging.config.fileConfig("logging.conf")
+utils.init_logging("lrrbot")
 
 from lrrbot.main import bot, log
 import lrrbot.commands

--- a/start_bot.py
+++ b/start_bot.py
@@ -1,14 +1,9 @@
 #!/usr/bin/env python3
 
-import logging
+import logging, logging.config
 from common.config import config
 
-logging.basicConfig(level=config['loglevel'], format="[%(asctime)s] %(levelname)s:%(name)s:%(message)s")
-if config['logfile'] is not None:
-	fileHandler = logging.FileHandler(config['logfile'], 'a', 'utf-8')
-	fileHandler.formatter = logging.root.handlers[0].formatter
-	logging.root.addHandler(fileHandler)
-logging.getLogger("requests").setLevel(logging.ERROR)
+logging.config.fileConfig("logging.conf")
 
 from lrrbot.main import bot, log
 import lrrbot.commands

--- a/webserver.py
+++ b/webserver.py
@@ -32,8 +32,7 @@ app.jinja_env.globals["max"] = max
 
 __all__ = ['app']
 
+utils.init_logging("webserver")
+
 if __name__ == '__main__':
 	app.run(debug=True, use_reloader=False)
-else:
-	import logging
-	app.logger.addHandler(logging.StreamHandler())


### PR DESCRIPTION
Set up rolling log files and a separate temporary file for debug logging, so that the debug logs are there if we need to look at them, but aren't kept forever taking up space.

I'm thinking of when I tried setting the bot to debug mode recently to look into it constantly reconnecting... but that required restarting the bot, which cleared the issue... would have been nice to have it doing full debug logging already... but we don't want to keep debug logs forever, that's just too much stuff we don't care about.

Note: I've checked that the logging conf loads properly, but I haven't tested the whole bot with this... I still need to update my comp to Python 3.5