### PR TITLE
Cheer tracking

### DIFF
--- a/alembic/versions/89c5cb66426d_add_bits_to_storm.py
+++ b/alembic/versions/89c5cb66426d_add_bits_to_storm.py
@@ -1,0 +1,15 @@
+revision = '89c5cb66426d'
+down_revision = '5aa73ff113c3'
+branch_labels = None
+depends_on = None
+
+import alembic
+import sqlalchemy
+
+def upgrade():
+	alembic.op.add_column('storm',
+		sqlalchemy.Column('twitch-cheer', sqlalchemy.Integer, nullable=False, server_default='0')
+	)
+
+def downgrade():
+	alembic.op.drop_column('storm', 'twitch-cheer')

--- a/common/storm.py
+++ b/common/storm.py
@@ -4,14 +4,14 @@ import sqlalchemy
 from common.config import config
 from common.sqlalchemy_pg95_upsert import DoUpdate
 
-def increment(engine, metadata, counter):
+def increment(engine, metadata, counter, by=1):
 	storm = metadata.tables['storm']
 	excluded = sqlalchemy.table('excluded', sqlalchemy.column(counter))
 	with engine.begin() as conn:
 		do_update = DoUpdate([storm.c.date]).set(**{counter: storm.c[counter] + excluded.c[counter]})
 		count, = conn.execute(storm.insert(postgresql_on_conflict=do_update).returning(storm.c[counter]), {
 			'date': datetime.datetime.now(config['timezone']).date(),
-			counter: 1,
+			counter: by,
 		}).first()
 	return count
 

--- a/lrrbot/chatlog.py
+++ b/lrrbot/chatlog.py
@@ -28,6 +28,9 @@ queue = asyncio.Queue()
 
 space.monkey_patch_urlize()
 
+re_cheer = re.compile(r"(?:^|(?<=\s))(cheer0*)([1-9][0-9]*)(?:$|(?=\s))", re.IGNORECASE)
+cheer_colors = [(0, 'gray'), (100, 'purple'), (1000, 'green'), (5000, 'blue'), (10000, 'red')]
+
 def urlize(text):
 	return real_urlize(text).replace('<a ', '<a target="_blank" rel="noopener nofollow" ')
 
@@ -149,7 +152,7 @@ def do_rebuild_all():
 		conn_select.close()
 		conn_update.close()
 
-def format_message(message, emotes):
+def format_message(message, emotes, cheer=False):
 	ret = ""
 	stack = [(message, "")]
 	while len(stack) != 0:
@@ -161,12 +164,12 @@ def format_message(message, emotes):
 				stack.append((parts[0], Markup(emote["html"].format(escape(parts[1])))))
 				break
 		else:
-			ret += Markup(urlize(prefix)) + suffix
+			ret += Markup(format_message_cheer(prefix, cheer=cheer)) + suffix
 	return ret
 
-def format_message_explicit_emotes(message, emotes, size="1.0"):
+def format_message_explicit_emotes(message, emotes, size="1", cheer=False):
 	if not emotes:
-		return Markup(urlize(message))
+		return Markup(format_message_cheer(message, size=size, cheer=cheer))
 
 	# emotes format is
 	# <emoteid>:<start>-<end>[,<start>-<end>,...][/<emoteid>:<start>-<end>,.../...]
@@ -189,14 +192,29 @@ def format_message_explicit_emotes(message, emotes, size="1.0"):
 	prev = 0
 	for start, end, emoteid in parsed_emotes:
 		if prev < start:
-			bits.append(urlize(message[prev:start]))
-		url = escape("https://static-cdn.jtvnw.net/emoticons/v1/%d/%s" % (emoteid, size))
+			bits.append(format_message_cheer(message[prev:start], size=size, cheer=cheer))
+		url = escape("https://static-cdn.jtvnw.net/emoticons/v1/%d/%s.0" % (emoteid, size))
 		command = escape(message[start:end])
 		bits.append('<img src="%s" alt="%s" title="%s">' % (url, command, command))
 		prev = end
 	if prev < len(message):
-		bits.append(urlize(message[prev:]))
+		bits.append(format_message_cheer(message[prev:], size=size, cheer=cheer))
 	return Markup(''.join(bits))
+
+def format_message_cheer(message, size="1", cheer=False):
+	if not cheer:
+		return urlize(message)
+	else:
+		bits = []
+		splits = re_cheer.split(message)
+		for i in range(0, len(splits), 3):
+			bits.append(urlize(splits[i]))
+			if i + 1 < len(splits):
+				count = int(splits[i + 2])
+				col = [col for cutoff, col in cheer_colors if cutoff <= count][-1]
+				url = escape("https://static-cdn.jtvnw.net/bits/light/static/%s/%s" % (col, size))
+				bits.append('<span class="cheer %s"><img src="%s" alt="%s" title="cheer %d">%d</span>' % (escape(col), url, escape(splits[i + 1]), count, count))
+		return ''.join(bits)
 
 @asyncio.coroutine
 def build_message_html(time, source, target, message, specialuser, usercolor, emoteset, emotes, displayname):
@@ -242,10 +260,10 @@ def build_message_html(time, source, target, message, specialuser, usercolor, em
 		# either for users to accidentally click, or for Google to see
 		ret.append('<span class="message cleared">%s</span>' % escape(message))
 	elif emotes is not None:
-		messagehtml = format_message_explicit_emotes(message, emotes)
+		messagehtml = format_message_explicit_emotes(message, emotes, cheer='cheer' in specialuser)
 		ret.append('<span class="message">%s</span>' % messagehtml)
 	else:
-		messagehtml = format_message(message, (yield from get_filtered_emotes(emoteset)))
+		messagehtml = format_message(message, (yield from get_filtered_emotes(emoteset)), cheer='cheer' in specialuser)
 		ret.append('<span class="message">%s</span>' % messagehtml)
 
 	if is_action:

--- a/lrrbot/chatlog.py
+++ b/lrrbot/chatlog.py
@@ -29,7 +29,6 @@ queue = asyncio.Queue()
 space.monkey_patch_urlize()
 
 re_cheer = re.compile(r"(?:^|(?<=\s))(cheer0*)([1-9][0-9]*)(?:$|(?=\s))", re.IGNORECASE)
-cheer_colors = [(0, 'gray'), (100, 'purple'), (1000, 'green'), (5000, 'blue'), (10000, 'red')]
 
 def urlize(text):
 	return real_urlize(text).replace('<a ', '<a target="_blank" rel="noopener nofollow" ')
@@ -211,9 +210,9 @@ def format_message_cheer(message, size="1", cheer=False):
 			bits.append(urlize(splits[i]))
 			if i + 1 < len(splits):
 				count = int(splits[i + 2])
-				col = [col for cutoff, col in cheer_colors if cutoff <= count][-1]
-				url = escape("https://static-cdn.jtvnw.net/bits/light/static/%s/%s" % (col, size))
-				bits.append('<span class="cheer %s"><img src="%s" alt="%s" title="cheer %d">%d</span>' % (escape(col), url, escape(splits[i + 1]), count, count))
+				level = lrrbot.twitchcheer.TwitchCheer.get_level(count)
+				url = escape("https://static-cdn.jtvnw.net/bits/light/static/%s/%s" % (level, size))
+				bits.append('<span class="cheer %s"><img src="%s" alt="%s" title="cheer %d">%d</span>' % (escape(level), url, escape(splits[i + 1]), count, count))
 		return ''.join(bits)
 
 @asyncio.coroutine

--- a/lrrbot/commands/misc.py
+++ b/lrrbot/commands/misc.py
@@ -39,12 +39,14 @@ def stormcount(lrrbot, conn, event, respond_to):
 	twitch_subscription = common.storm.get(lrrbot.engine, lrrbot.metadata, 'twitch-subscription')
 	twitch_resubscription = common.storm.get(lrrbot.engine, lrrbot.metadata, 'twitch-resubscription')
 	twitch_follow = common.storm.get(lrrbot.engine, lrrbot.metadata, 'twitch-follow')
+	twitch_cheer = common.storm.get(lrrbot.engine, lrrbot.metadata, 'twitch-cheer')
 	patreon_pledge = common.storm.get(lrrbot.engine, lrrbot.metadata, 'patreon-pledge')
-	conn.privmsg(respond_to, "Today's storm count (number of new subscribers): %d, combo count (number of returning subscribers): %d, power-up count (number of new patrons): %d, %s count (number of new followers): %d" % (
+	conn.privmsg(respond_to, "Today's storm count (number of new subscribers): %d, combo count (number of returning subscribers): %d, power-up count (number of new patrons): %d, %s count (number of new followers): %d, bits cheered: %d" % (
 		twitch_subscription,
 		twitch_resubscription,
 		patreon_pledge,
 		utils.counter(), twitch_follow,
+		twitch_cheer,
 	))
 
 @bot.command("spam(?:count)?")

--- a/lrrbot/main.py
+++ b/lrrbot/main.py
@@ -26,6 +26,7 @@ from lrrbot import command_parser
 from lrrbot import rpc
 from lrrbot import join_filter
 from lrrbot import twitchfollows
+from lrrbot import twitchcheer
 
 log = logging.getLogger('lrrbot')
 
@@ -119,6 +120,7 @@ class LRRBot(irc.bot.SingleServerIRCBot):
 		self.subs = twitchsubs.TwitchSubs(self, loop)
 		self.join_filter = join_filter.JoinFilter(self, loop)
 		self.twitchfollows = twitchfollows.TwitchFollows(self, loop)
+		self.twitchcheer = twitchcheer.TwitchCheer(self, loop)
 
 	def reactor_class(self):
 		return asyncreactor.AsyncReactor(self.loop)

--- a/lrrbot/main.py
+++ b/lrrbot/main.py
@@ -212,6 +212,8 @@ class LRRBot(irc.bot.SingleServerIRCBot):
 			metadata['specialuser'].add(event.tags.get('user-type'))
 		if event.tags['mod']:
 			metadata['specialuser'].add('mod')
+		if event.tags.get('bits'):
+			metadata['specialuser'].add('cheer')
 		log.debug("Message metadata: %r", metadata)
 		chatlog.log_chat(event, metadata)
 
@@ -239,6 +241,9 @@ class LRRBot(irc.bot.SingleServerIRCBot):
 		is_mod = is_mod or tags.get('user-type', '') in {'mod', 'global_mod', 'admin', 'staff'}
 		#  * is broadcaster
 		tags["mod"] = is_mod = is_mod or nick.lower() == config['channel']
+
+		if 'bits' in tags:
+			tags['bits'] = int(tags['bits'])
 
 		if "user-id" not in tags:
 			tags["display_name"] = tags.get("display_name", nick)

--- a/lrrbot/twitchcheer.py
+++ b/lrrbot/twitchcheer.py
@@ -1,0 +1,44 @@
+import asyncio
+import common.rpc
+import common.storm
+from common import twitch
+from common import utils
+
+import irc.client
+
+import logging
+
+log = logging.getLogger('cheer')
+
+class TwitchCheer:
+	LEVELS = [(10000, 'red'), (5000, 'blue'), (1000, 'green'), (100, 'purple'), (1, 'gray')]
+
+	def __init__(self, lrrbot, loop):
+		self.loop = loop
+		self.lrrbot = lrrbot
+		self.lrrbot.reactor.add_global_handler("pubmsg", self.check_cheer, 100)
+
+	def check_cheer(self, conn, event):
+		if event.tags.get('bits'):
+			asyncio.ensure_future(self.on_cheer(event)).add_done_callback(utils.check_exception)
+
+	async def on_cheer(self, event):
+		log.info("Got %d bits from %s", event.tags['bits'], event.tags['display_name'])
+		eventname = 'twitch-cheer'
+		data = {
+			'name': event.tags['display_name'],
+			'message': event.arguments[0],
+			'bits': event.tags['bits'],
+			'count': common.storm.increment(self.lrrbot.engine, self.lrrbot.metadata, eventname, event.tags['bits']),
+			'level': self.get_level(event.tags['bits']),
+		}
+
+		await common.rpc.eventserver.event(eventname, data, None)
+
+	@classmethod
+	def get_level(cls, bits):
+		for cutoff, level in cls.LEVELS:
+			if bits >= cutoff:
+				return level
+		else:
+			return "gray"

--- a/www/api.py
+++ b/www/api.py
@@ -36,6 +36,7 @@ def stormcount():
 		'twitch-subscription': common.storm.get(server.db.engine, server.db.metadata, 'twitch-subscription'),
 		'twitch-resubscription': common.storm.get(server.db.engine, server.db.metadata, 'twitch-resubscription'),
 		'twitch-follow': common.storm.get(server.db.engine, server.db.metadata, 'twitch-follow'),
+		'twitch-cheer': common.storm.get(server.db.engine, server.db.metadata, 'twitch-cheer'),
 		'patreon-pledge': common.storm.get(server.db.engine, server.db.metadata, 'patreon-pledge'),
 	})
 

--- a/www/notifications.py
+++ b/www/notifications.py
@@ -17,7 +17,7 @@ def get_events():
 	recent_events = []
 	query = sqlalchemy.select([events.c.id, events.c.event, events.c.data, events.c.time, sqlalchemy.func.current_timestamp() - events.c.time]) \
 		.where(events.c.time > sqlalchemy.func.current_timestamp() - datetime.timedelta(days=2)) \
-		.where(events.c.event.in_({'twitch-subscription', 'twitch-resubscription', 'twitch-message', 'patreon-pledge'})) \
+		.where(events.c.event.in_({'twitch-subscription', 'twitch-resubscription', 'twitch-message', 'twitch-cheer', 'patreon-pledge'})) \
 		.order_by(events.c.time.desc())
 	with server.db.engine.begin() as conn:
 		for id, event, data, time, duration in conn.execute(query):

--- a/www/static/archive.css
+++ b/www/static/archive.css
@@ -90,31 +90,6 @@ img
 	display: none;
 }
 
-.cheer
-{
-	font-weight: bold;
-}
-.cheer.gray
-{
-	color: #979797;
-}
-.cheer.purple
-{
-	color: #9c3ee8;
-}
-.cheer.green
-{
-	color: #1db2a5;
-}
-.cheer.blue
-{
-	color: #0099fe;
-}
-.cheer.red
-{
-	color: #f43021;
-}
-
 #resetscroll
 {
 	position: fixed;

--- a/www/static/archive.css
+++ b/www/static/archive.css
@@ -90,6 +90,31 @@ img
 	display: none;
 }
 
+.cheer
+{
+	font-weight: bold;
+}
+.cheer.gray
+{
+	color: #979797;
+}
+.cheer.purple
+{
+	color: #9c3ee8;
+}
+.cheer.green
+{
+	color: #1db2a5;
+}
+.cheer.blue
+{
+	color: #0099fe;
+}
+.cheer.red
+{
+	color: #f43021;
+}
+
 #resetscroll
 {
 	position: fixed;

--- a/www/static/notifications.js
+++ b/www/static/notifications.js
@@ -17,6 +17,10 @@ window.addEventListener('DOMContentLoaded', function (event) {
 			twitch_resubscription(JSON.parse(event.data));
 			update_title();
 		});
+		stream.addEventListener("twitch-cheer", function (event) {
+			twitch_cheer(JSON.parse(event.data));
+			update_title();
+		});
 		stream.addEventListener("twitch-message", function (event) {
 			twitch_message(JSON.parse(event.data));
 			update_title();
@@ -182,6 +186,42 @@ function twitch_resubscription(data) {
 		link.appendChild(document.createTextNode(data.name));
 		message.appendChild(link);
 		message.appendChild(document.createTextNode(" subscribed for " + data.monthcount + " month" + (data.monthcount != 1 ? 's' : '') + " in a row!"));
+		message_container.appendChild(message);
+
+		if (data.message) {
+			var user_message = createElementWithClass("p", "message");
+			message_container.appendChild(user_message);
+			var quote = document.createElement("q");
+			quote.appendChild(document.createTextNode(data.message));
+			user_message.appendChild(quote);
+		}
+	});
+}
+
+function twitch_cheer(data) {
+	create_row(data, function (container) {
+		var user = createElementWithClass("div", "user with-avatar");
+		container.appendChild(user);
+
+		var link = document.createElement("a");
+		link.href = "https://www.twitch.tv/" + data.name;
+		link.rel = "noopener nofollow";
+
+		var avatar = document.createElement("img");
+		avatar.src = "https://static-cdn.jtvnw.net/bits/light/static/" + data.level + "/3";
+		user.appendChild(avatar);
+
+		var message_container = createElementWithClass("div", "message-container");
+		user.appendChild(message_container);
+
+		var message = createElementWithClass("p", "system-message");
+		link.appendChild(document.createTextNode(data.name));
+		message.appendChild(link);
+		message.appendChild(document.createTextNode(" has cheered with "));
+		var bits = createElementWithClass("span", "cheer " + data.level);
+		bits.appendChild(document.createTextNode(data.bits));
+		message.appendChild(bits);
+		message.appendChild(document.createTextNode(" bits!"));
 		message_container.appendChild(message);
 
 		if (data.message) {

--- a/www/static/style.css
+++ b/www/static/style.css
@@ -645,3 +645,28 @@ table.quote-search select {
 .flash-success {
 	background-color: #dff0d8;
 }
+
+.cheer
+{
+	font-weight: bold;
+}
+.cheer.gray
+{
+	color: #979797;
+}
+.cheer.purple
+{
+	color: #9c3ee8;
+}
+.cheer.green
+{
+	color: #1db2a5;
+}
+.cheer.blue
+{
+	color: #0099fe;
+}
+.cheer.red
+{
+	color: #f43021;
+}

--- a/www/templates/notifications.html
+++ b/www/templates/notifications.html
@@ -43,6 +43,19 @@
 							{% endif %}
 						</div>
 					</div>
+				{% elif event['event'] == 'twitch-cheer' %}
+					<div class="user with-avatar">
+						<img class="avatar" src="https://static-cdn.jtvnw.net/bits/light/static/{{ event['data']['level'] }}/3">
+						<div class="message-container">
+							<p class="system-message">
+								<a href="https://www.twitch.tv/{{ event['data']['name'] }}" rel="noopener nofollow">{{ event['data']['name'] }}</a> has cheered with
+									<span class="cheer {{ event['data']['level'] }}">{{ event['data']['bits'] }}</span> bits!
+							</p>
+							{% if event['data']['message'] %}
+								<p class="message"><q>{{ event['data']['message'] }}</q></p>
+							{% endif %}
+						</div>
+					</div>
 				{% elif event['event'] == 'twitch-message' %}
 					<div class="message">{{ event['data']['message'] }}</div>
 				{% elif event['event'] == 'patreon-pledge' %}


### PR DESCRIPTION
Closes #235 

Note for @paul-lrr:
The messages for these will come down the same as all the other event notifications, with the event type `twitch-cheer`. The data block looks like:
```json
{
  "name": "MrPhlip",
  "message": "Testing out this cheer thing... cheer50",
  "bits": 50,
  "count": 123456,
  "level": "gray"
}
```
Where `bits` is the number of bits in this message;  `count` is the running total for the day. `level` is one of: gray, purple, green, blue, or red.