### PR TITLE
Fix database schema inconsistencies

### DIFF
--- a/alembic/versions/0dec7733925d_rename_highlights_user.py
+++ b/alembic/versions/0dec7733925d_rename_highlights_user.py
@@ -1,0 +1,13 @@
+revision = '0dec7733925d'
+down_revision = '7c9bbf3a039a'
+branch_labels = None
+depends_on = None
+
+import alembic
+import sqlalchemy
+
+def upgrade():
+	alembic.op.alter_column('highlights', 'user', new_column_name="user_id")
+
+def downgrade():
+	alembic.op.alter_column('highlights', 'user_id', new_column_name="user")

--- a/alembic/versions/0e33b11b0930_drop_patreon_users_last_announce_month.py
+++ b/alembic/versions/0e33b11b0930_drop_patreon_users_last_announce_month.py
@@ -1,0 +1,13 @@
+revision = '0e33b11b0930'
+down_revision = '286bd48821dd'
+branch_labels = None
+depends_on = None
+
+import alembic
+import sqlalchemy
+
+def upgrade():
+	alembic.op.drop_column('patreon_users', 'last_announce_month')
+
+def downgrade():
+	alembic.op.add_column('patreon_users', sqlalchemy.Column("last_announce_month", sqlalchemy.Integer))

--- a/alembic/versions/286bd48821dd_rename_users_patreon_user.py
+++ b/alembic/versions/286bd48821dd_rename_users_patreon_user.py
@@ -1,0 +1,13 @@
+revision = '286bd48821dd'
+down_revision = '0dec7733925d'
+branch_labels = None
+depends_on = None
+
+import alembic
+import sqlalchemy
+
+def upgrade():
+	alembic.op.alter_column('users', 'patreon_user', new_column_name="patreon_user_id")
+
+def downgrade():
+	alembic.op.alter_column('users', 'patreon_user_id', new_column_name="patreon_user")

--- a/alembic/versions/7c9bbf3a039a_game_stats_stat_id.py
+++ b/alembic/versions/7c9bbf3a039a_game_stats_stat_id.py
@@ -1,0 +1,43 @@
+revision = '7c9bbf3a039a'
+down_revision = '89c5cb66426d'
+branch_labels = None
+depends_on = None
+
+import alembic
+import sqlalchemy
+
+def upgrade():
+	conn = alembic.context.get_context().bind
+	meta = sqlalchemy.MetaData(bind=conn)
+	meta.reflect()
+	game_stats = meta.tables["game_stats"]
+	shows = meta.tables["shows"]
+
+	constraint_name = None
+	for fk in game_stats.c.stat_id.foreign_keys:
+		if fk.column.table is shows and fk.column.name == "id":
+			constraint_name = fk.name
+			break
+	else:
+		raise Exception("Failed to find a foreign key on `game_stats.stat_id` that references `shows.id`")
+
+	alembic.op.drop_constraint(constraint_name, 'game_stats')
+	alembic.op.create_foreign_key(constraint_name, 'game_stats', 'stats', ["stat_id"], ["id"], onupdate="CASCADE", ondelete="CASCADE")
+
+def downgrade():
+	conn = alembic.context.get_context().bind
+	meta = sqlalchemy.MetaData(bind=conn)
+	meta.reflect()
+	game_stats = meta.tables["game_stats"]
+	stats = meta.tables["stats"]
+
+	constraint_name = None
+	for fk in game_stats.c.stat_id.foreign_keys:
+		if fk.column.table is stats and fk.column.name == "id":
+			constraint_name = fk.name
+			break
+	else:
+		raise Exception("Failed to find a foreign key on `game_stats.stat_id` that references `stats.id`")
+
+	alembic.op.drop_constraint(constraint_name, 'game_stats')
+	alembic.op.create_foreign_key(constraint_name, 'game_stats', 'shows', ["stat_id"], ["id"], onupdate="CASCADE", ondelete="CASCADE")

--- a/common/patreon.py
+++ b/common/patreon.py
@@ -40,7 +40,7 @@ def get_token(engine, metadata, user):
 			patreon_users.c.token_expires,
 		])
 		query = filter_by_user(query, user)
-		row = conn.execute(query.select_from(users.join(patreon_users, users.c.patreon_user == patreon_users.c.id))).first()
+		row = conn.execute(query.select_from(users.join(patreon_users, users.c.patreon_user_id == patreon_users.c.id))).first()
 		if row is None:
 			raise Exception("User not logged in")
 		patreon_id, access_token, refresh_token, expiry = row

--- a/highlights.py
+++ b/highlights.py
@@ -22,7 +22,7 @@ def get_staged_highlights():
 			"nick": highlight[4],
 		} for highlight in conn.execute(sqlalchemy.select([
 			highlights.c.id, highlights.c.title, highlights.c.description, highlights.c.time, users.c.display_name
-		]).select_from(highlights.join(users, highlights.c.user == users.c.id)))]
+		]).select_from(highlights.join(users, highlights.c.user_id == users.c.id)))]
 
 def delete_staged_highlights(highlights):
 	if len(highlights) == 0:

--- a/lrrbot/commands/highlights.py
+++ b/lrrbot/commands/highlights.py
@@ -36,7 +36,7 @@ def highlight(lrrbot, conn, event, respond_to, description):
 	else:
 		with lrrbot.engine.begin() as pg_conn:
 			pg_conn.execute(lrrbot.metadata.tables["highlights"].insert(),
-				title=stream_info["status"], description=description, time=now, user=event.tags["user-id"])
+				title=stream_info["status"], description=description, time=now, user_id=event.tags["user-id"])
 		conn.privmsg(respond_to, "Highlight added.")
 		return
 

--- a/www/login.py
+++ b/www/login.py
@@ -211,9 +211,9 @@ async def load_session(include_url=True, include_header=True):
 		with server.db.engine.begin() as conn:
 			query = sqlalchemy.select([
 				users.c.name, sqlalchemy.func.coalesce(users.c.display_name, users.c.name), users.c.twitch_oauth,
-				users.c.is_sub, users.c.is_mod, users.c.autostatus, users.c.patreon_user
+				users.c.is_sub, users.c.is_mod, users.c.autostatus, users.c.patreon_user_id
 			]).where(users.c.id == user_id)
-			name, display_name, token, is_sub, is_mod, autostatus, patreon_user = conn.execute(query).first()
+			name, display_name, token, is_sub, is_mod, autostatus, patreon_user_id = conn.execute(query).first()
 			session['user'] = {
 				"id": user_id,
 				"name": name,
@@ -222,7 +222,7 @@ async def load_session(include_url=True, include_header=True):
 				"is_sub": is_sub,
 				"is_mod": is_mod,
 				"autostatus": autostatus,
-				"patreon_user": patreon_user,
+				"patreon_user_id": patreon_user_id,
 			}
 	else:
 		session['user'] = {

--- a/www/patreon.py
+++ b/www/patreon.py
@@ -36,7 +36,7 @@ def patreon_index(session):
 			.select_from(users.join(patreon_users))
 			.where(users.c.name == config['channel'])).first()
 
-	if session['user']['patreon_user'] is None:
+	if session['user']['patreon_user_id'] is None:
 		state = base64.urlsafe_b64encode(os.urandom(18)).decode('ascii')
 		flask.session['patreon_state'] = state
 		pledge_url = None
@@ -197,7 +197,7 @@ async def patreon_webhooks():
 					full_name=patron['attributes']['full_name'],
 					pledge_start=pledge_start,
 			).first()
-			twitch_user = conn.execute(sqlalchemy.select([users.c.name]).where(users.c.patreon_user == patron_id)).first()
+			twitch_user = conn.execute(sqlalchemy.select([users.c.name]).where(users.c.patreon_user_id == patron_id)).first()
 			if twitch_user is not None:
 				twitch_user = {
 					'name': twitch_user[0]

--- a/www/templates/patreon.html
+++ b/www/templates/patreon.html
@@ -3,7 +3,7 @@
 {%block header%}Patreon{%endblock%}
 {%block content%}
 
-{% if session['user']['patreon_user'] is none %}
+{% if session['user']['patreon_user_id'] is none %}
 <p>You haven't yet linked your Patreon account. Patrons with linked Patreon accounts can use
 	subscriber-only commands even when they're not subscribers. There also might be other
 	effects.</p>


### PR DESCRIPTION
* Update the foreign key on `game_stats.stat_id` to reference `stats.id` instead of `shows.id`. Closes #250.
* Rename `highlights.user` to `highlights.user_id`.
* Rename `users.pateron_user` to `users.patreon_user_id`.
* Drop `patreon_users.last_announce_month`. It was never used and never will.