### PR TITLE
discord: temporary voice channels

### DIFF
--- a/common/config.py
+++ b/common/config.py
@@ -123,3 +123,6 @@ config.setdefault('discord_botsecret', '')
 
 # discord_serverid - ID of the LRR Discord server
 config.setdefault('discord_serverid', '288920509272555520')
+
+# discord_temp_channel_prefix - prefix of a temporary channel
+config.setdefault('discord_temp_channel_prefix', '[TEMP] ')

--- a/common/config.py
+++ b/common/config.py
@@ -125,4 +125,4 @@ config.setdefault('discord_botsecret', '')
 config.setdefault('discord_serverid', '288920509272555520')
 
 # discord_temp_channel_prefix - prefix of a temporary channel
-config.setdefault('discord_temp_channel_prefix', '[TEMP] ')
+config.setdefault('discord_temp_channel_prefix', config.get('discord_temp_channel_prefix', '[TEMP]').strip() + ' ')

--- a/eris/__init__.py
+++ b/eris/__init__.py
@@ -1,1 +1,2 @@
 import eris.autotopic
+import eris.channel_reaper

--- a/eris/channel_reaper.py
+++ b/eris/channel_reaper.py
@@ -1,0 +1,40 @@
+import asyncio
+import datetime
+import pytz
+
+import discord
+
+from common.config import config
+from common import utils
+
+import logging
+log = logging.getLogger('eris.channel_reaper')
+
+class ChannelReaper:
+	def __init__(self, eris, signals):
+		self.eris = eris
+		self.signals = signals
+
+		self.timer_scheduled = False
+		self.signals.signal('ready').connect(self.schedule_timer)
+
+	@utils.swallow_errors
+	async def reap_channels(self):
+		for channel in list(self.eris.get_server(config['discord_serverid']).channels):
+			if channel.type != discord.ChannelType.voice:
+				continue
+			if not channel.name.startswith(config['discord_temp_channel_prefix']):
+				continue
+			channel_age = datetime.datetime.now(pytz.utc) - pytz.utc.localize(channel.created_at)
+			if channel_age > datetime.timedelta(minutes=15) and len(channel.voice_members) == 0:
+				log.info("Deleting %r (%r) due to no activity.", channel.name, channel.id)
+				await self.eris.delete_channel(channel)
+
+	def schedule_reap_channels(self):
+		asyncio.ensure_future(self.reap_channels(), loop=self.eris.loop).add_done_callback(utils.check_exception)
+		self.eris.loop.call_later(60, self.schedule_reap_channels)
+
+	def schedule_timer(self, eris):
+		if not self.timer_scheduled:
+			self.timer_scheduled = True
+			self.schedule_reap_channels()

--- a/eris/commands/__init__.py
+++ b/eris/commands/__init__.py
@@ -1,4 +1,6 @@
 import eris.commands.live
+import eris.commands.voice
 
 def register(command_parser):
     eris.commands.live.register(command_parser)
+    eris.commands.voice.register(command_parser)

--- a/eris/commands/live.py
+++ b/eris/commands/live.py
@@ -22,7 +22,7 @@ def register(bot):
 
 		streams = await twitch.get_streams_followed(token)
 		if len(streams) == 0:
-			return conn.privmsg(respond_to, "No fanstreamers currently live.")
+			return bot.eris.send_message(command.channel, "No fanstreamers currently live.")
 
 		streams.sort(key=lambda e: e["channel"]["display_name"])
 

--- a/eris/commands/voice.py
+++ b/eris/commands/voice.py
@@ -1,0 +1,11 @@
+import discord
+from common.config import config
+
+def register(bot):
+	@bot.command("voice (.*?)")
+	async def live(bot, command, desc):
+		if command.server is None:
+			await bot.eris.send_message(command.channel, "Can't create temporary voice channels over private messages.")
+			return
+		channel = await bot.eris.create_channel(command.server, config['discord_temp_channel_prefix'] + desc, type=discord.ChannelType.voice)
+		await bot.eris.send_message(command.channel, "Created a temporary voice channel %r." % desc)

--- a/start_eris.py
+++ b/start_eris.py
@@ -6,6 +6,7 @@ from common.config import config
 from common import postgres
 from common import utils
 from eris.autotopic import Autotopic
+from eris.channel_reaper import ChannelReaper
 from eris.command_parser import CommandParser
 from eris.commands import register as register_commands
 
@@ -150,6 +151,7 @@ async def on_group_remove(channel, user):
 	signals.signal('group_remove').send(eris, channel=channel, user=user)
 
 autotopic = Autotopic(eris, signals, engine, metadata)
+channel_reaper = ChannelReaper(eris, signals)
 command_parser = CommandParser(eris, signals, engine, metadata)
 register_commands(command_parser)
 


### PR DESCRIPTION
New command: `!voice CHANNEL`. It creates a new voice channel named '[TEMP] CHANNEL'.

Once a minute all voice channels that start with `[TEMP] `, are empty and are older than fifteen minutes are deleted.

