### PR TITLE
Stream start and end notifications

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+indent_style = tab

--- a/common/config.py
+++ b/common/config.py
@@ -66,11 +66,14 @@ config['timezone'] = pytz.timezone(config.get('timezone', 'America/Vancouver'))
 config.setdefault('socket_filename', 'lrrbot.sock')
 # eventsocket - Filename for the UDS channel that the webserver uses to communicate with SSE clients
 config.setdefault('eventsocket', "/tmp/eventserver.sock")
+# eris_socket - Filename for the UDS channel that the Discord bot uses.
+config.setdefault('eris_socket', 'eris.sock')
 
 # socket_port - TCP port to use when Unix domain sockets are not available.
 config['socket_port'] = int(config.get('socket_port', 49601))
 # event_port - TCP port to use when Unix domain sockets are not available.
 config['event_port'] = int(config.get('event_port', 49602))
+config['eris_port'] = int(config.get('event_port', 49603))
 
 # google_key - Google API key
 config.setdefault('google_key', '')
@@ -126,6 +129,9 @@ config.setdefault('discord_serverid', '288920509272555520')
 
 # discord_temp_channel_prefix - prefix of a temporary channel
 config['discord_temp_channel_prefix'] = config.get('discord_temp_channel_prefix', '[TEMP]').strip() + ' '
+
+# discord_channel_announcements - ID of #announcements
+config['discord_channel_annoucements'] = "322643668831961088"
 
 # log_desertbus_moderator_actions - log moderator actions in #desertbus
 config['log_desertbus_moderator_actions'] = str(config.get('log_desertbus_moderator_actions', 'true')).lower() != 'false'

--- a/common/rpc.py
+++ b/common/rpc.py
@@ -82,3 +82,4 @@ class Client:
 
 bot = Client(config['socket_filename'], config['socket_port'])
 eventserver = Client(config['eventsocket'], config['event_port'])
+eris = Client(config['eris_socket'], config['eris_port'])

--- a/common/rpc.py
+++ b/common/rpc.py
@@ -36,7 +36,8 @@ class Server:
 	async def close(self):
 		self.__server.close()
 		await self.__server.wait_closed()
-		await asyncio.gather(client.close() for client in self.__clients)
+		for client in self.__clients:
+			await client.close()
 
 class Proxy:
 	def __init__(self, client, path):

--- a/common/rpc.py
+++ b/common/rpc.py
@@ -9,11 +9,7 @@ from common.config import config
 
 log = logging.getLogger('common.rpc')
 
-try:
-	CODEC = aiomas.codecs.MsgPack()
-	CODEC = aiomas.codecs.MsgPack
-except ImportError:
-	CODEC = aiomas.codecs.JSON
+CODEC = aiomas.codecs.MsgPack
 EXTRA_SERIALIZERS = [
 	lambda: (datetime.datetime, lambda t: t.timestamp(), lambda t: datetime.datetime.fromtimestamp(t, pytz.utc))
 ]

--- a/eris/__init__.py
+++ b/eris/__init__.py
@@ -1,2 +1,0 @@
-import eris.autotopic
-import eris.channel_reaper

--- a/eris/announcements.py
+++ b/eris/announcements.py
@@ -1,0 +1,49 @@
+import aiomas
+import logging
+import sqlalchemy
+
+from common import rpc
+from common import twitch
+from common.config import config
+
+log = logging.getLogger(__name__)
+
+class Announcements:
+	router = aiomas.rpc.Service()
+
+	def __init__(self, eris, signals, engine, metadata):
+		self.eris = eris
+		self.signals = signals
+		self.engine = engine
+		self.metadata = metadata
+
+	@aiomas.expose
+	async def stream_up(self, data):
+		channel = self.eris.get_server(config['discord_serverid']).get_channel(config['discord_channel_announcements'])
+		if channel is None:
+			log.error("No announcements channel")
+			return
+
+		game_id = await rpc.bot.get_game_id()
+		show_id = await rpc.bot.get_show_id()
+
+		games = self.metadata.tables['games']
+		shows = self.metadata.tables['shows']
+		game_per_show_data = self.metadata.tables['game_per_show_data']
+
+		with self.engine.begin() as conn:
+			show, = conn.execute(sqlalchemy.select([shows.c.name]).where(shows.c.id == show_id)).first()
+
+			if game_id is not None:
+				game, = conn.execute(sqlalchemy.select([games.c.name])
+					.select_from(
+						games
+							.outerjoin(game_per_show_data,
+								(games.c.id == game_per_show_data.c.game_id) & (game_per_show_data.c.show_id == show_id)
+							)
+					).where(games.c.id == game_id)).first()
+				description = "%s on %s" % (game, show)
+			else:
+				description = show
+
+		await self.eris.send_message(channel, "%s is live with %s (%s)! %s" % (data['display_name'], description, data['status'], data['url']))

--- a/eris/autotopic.py
+++ b/eris/autotopic.py
@@ -46,7 +46,7 @@ class Autotopic:
 			games = self.metadata.tables["games"]
 			game_per_show_data = self.metadata.tables["game_per_show_data"]
 			with self.engine.begin() as conn:
-				if header['current_game']:
+				if header.get('current_game'):
 					game = conn.execute(sqlalchemy.select([
 						sqlalchemy.func.coalesce(game_per_show_data.c.display_name, games.c.name)
 					]).select_from(
@@ -59,7 +59,7 @@ class Autotopic:
 				else:
 					game = None
 				
-				if header['current_show']:
+				if header.get('current_show'):
 					show = conn.execute(sqlalchemy.select([shows.c.name])
 						.where(shows.c.id == header['current_show']['id'])
 						.where(shows.c.string_id != "")).first()

--- a/eris/rpc.py
+++ b/eris/rpc.py
@@ -1,0 +1,9 @@
+import aiomas
+
+from common import rpc
+
+class Server(rpc.Server):
+	router = aiomas.rpc.Service(['announcements'])
+
+	def __init__(self):
+		self.announcements = None

--- a/lrrbot/main.py
+++ b/lrrbot/main.py
@@ -30,6 +30,7 @@ from lrrbot import twitchfollows
 from lrrbot import twitchcheer
 from lrrbot import moderator_actions
 from lrrbot import desertbus_moderator_actions
+from lrrbot import video_playback
 
 log = logging.getLogger('lrrbot')
 
@@ -132,6 +133,7 @@ class LRRBot(irc.bot.SingleServerIRCBot):
 		self.twitchcheer = twitchcheer.TwitchCheer(self, loop)
 		self.moderator_actions = moderator_actions.ModeratorActions(self, loop)
 		self.desertbus_moderator_actions = desertbus_moderator_actions.ModeratorActions(self, loop)
+		self.video_playback = video_playback.VideoPlayback(self, loop)
 
 	def reactor_class(self):
 		return asyncreactor.AsyncReactor(self.loop)

--- a/lrrbot/stream_status.py
+++ b/lrrbot/stream_status.py
@@ -1,0 +1,4 @@
+class StreamStatus:
+	def __init__(self, lrrbot, loop):
+		self.lrrbot = lrrbot
+		self.loop = loop

--- a/lrrbot/stream_status.py
+++ b/lrrbot/stream_status.py
@@ -1,4 +1,40 @@
+import asyncio
+import logging
+
+from common import twitch
+from common import rpc
+from common import utils
+
+log = logging.getLogger(__name__)
+
 class StreamStatus:
 	def __init__(self, lrrbot, loop):
 		self.lrrbot = lrrbot
 		self.loop = loop
+
+		self.handle = self.loop.call_later(twitch.GAME_CHECK_INTERVAL, self.schedule)
+		self.was_live = bool(twitch.is_stream_live())
+
+	def reschedule(self):
+		self.handle.cancel()
+		self.schedule()
+
+	def schedule(self):
+		asyncio.ensure_future(self.check_stream(), loop=self.loop).add_done_callback(utils.check_exception)
+
+	async def check_stream(self):
+		log.debug("Checking stream")
+		data = twitch.get_info(use_fallback=False)
+		is_live = bool(data and data['live'])
+
+		if is_live and not self.was_live:
+			log.debug("Stream is now live")
+			await rpc.eventserver.event('stream-up', {}, None)
+			await rpc.eris.announcements.stream_up(data)
+		elif not is_live and self.was_live:
+			log.debug("Stream is now offline")
+			await rpc.eventserver.event('stream-down', {}, None)
+
+		self.was_live = is_live
+
+		self.handle = self.loop.call_later(twitch.GAME_CHECK_INTERVAL, self.schedule)

--- a/lrrbot/video_playback.py
+++ b/lrrbot/video_playback.py
@@ -1,0 +1,78 @@
+"""
+# Undocumented PubSub topic: `video-playback.<channel name>` or `video-playback-by-id.<channel ID>`
+
+## `stream-up` message:
+Sent when stream goes live.
+
+Example: '{"play_delay": 0, "type": "stream-up", "server_time": 1497116829.584907}'
+
+## `viewcount` message:
+They seem to be sent every five seconds while stream is live.
+
+Example: '{"type":"viewcount","server_time":1497148129.038571,"viewers":482}'
+
+## `commercial` message:
+Example: '{"type": "commercial", "length": 180, "server_time": 1497148003.553933}'
+
+## `stream-down` message:
+Sent when stream goes offline.
+
+Example: '{"type": "stream-down", "server_time": 1497148117.77978}'
+"""
+
+import sqlalchemy
+from common import pubsub
+from common import twitch
+from common import utils
+from common.config import config
+import logging
+
+log = logging.getLogger(__name__)
+
+class VideoPlayback:
+	def __init__(self, lrrbot, loop):
+		self.lrrbot = lrrbot
+		self.loop = loop
+
+		users = self.lrrbot.metadata.tables["users"]
+		with self.lrrbot.engine.begin() as conn:
+			row = conn.execute(sqlalchemy.select([users.c.id, users.c.name]).where(users.c.name == config['username'])).first()
+		if row is not None:
+			channel_id, channel_name = row
+
+			topics = ["video-playback.%s" % channel_name, "video-playback-by-id.%s" % channel_id]
+
+			self.lrrbot.pubsub.subscribe(topics)
+
+			for topic in topics:
+				pubsub.signals.signal(topic).connect(self.on_message)
+
+	@utils.cache(period=20)
+	def flush_caches(self):
+		log.debug("Flushing stream data cache")
+		twitch.get_info.reset_throttle()
+		self.lrrbot.get_game_id.reset_throttle()
+	
+	def flush_caches_until(self, stream_is_live):
+		self.flush_caches()
+
+		log.debug("Checking stream status")
+		try:
+			retry = twitch.get_info()['live'] != stream_is_live
+		except utils.PASSTHROUGH_EXCEPTIONS:
+			raise
+		except Exception:
+			log.exception("Error while checking stream status")
+			retry = True
+		
+		if retry:
+			log.debug("Stream not in desired state, retrying in 30 seconds")
+			self.loop.call_later(30, self.flush_caches_until, stream_is_live)
+		else:
+			log.debug("Stream is in the desired state")
+
+	def on_message(self, sender, message):
+		if message["type"] == "stream-up":
+			self.flush_caches_until(stream_is_live=True)
+		elif message["type"] == "stream-down":
+			self.flush_caches_until(stream_is_live=False)

--- a/requirements-direct.txt
+++ b/requirements-direct.txt
@@ -3,7 +3,7 @@
 # No version numbers are used unless necessary.
 
 aiohttp
-aiomas
+aiomas[mp]
 alembic
 async_timeout
 blinker

--- a/requirements.txt
+++ b/requirements.txt
@@ -54,3 +54,4 @@ websockets==3.3
 Werkzeug==0.12.2
 yarl==0.10.3
 regex==2017.06.07
+msgpack-python==0.4.8


### PR DESCRIPTION
It polls the stream endpoint but also uses the undocumented and unsupported `video-playback` PubSub topic to flush the caches early. This should mean that if `video-playback` disappears the rest should still continue to work. Because we can't rely on `video-playback` the notifications are delayed by several minutes due to Twitch's internal caches.

New events in the notification stream:
```
id:46829
event:stream-up
data:{"time": "2017-06-16T16:21:54.365842+00:00"}

id:46830
event:stream-down
data:{"time": "2017-06-16T16:28:23.085681+00:00"}
```

LRRbot will also post a notification in Discord.