### PR TITLE
Fix spacebar keypress handling in firefox

### DIFF
--- a/www/static/archive.js
+++ b/www/static/archive.js
@@ -122,7 +122,7 @@ function startScrolling() {
 }
 
 function onKeypress(e) {
-	if (e.keyCode === 0 || e.keyCode === 32) {
+	if (e.key === " " || e.key === "Spacebar" || e.keyCode === 32) {
 		if (window.player.isPaused())
 			window.player.play();
 		else


### PR DESCRIPTION
I recently changed from viewing the archives in chrome to firefox and I stopped being able to use Ctrl+F to open search. I'm guessing this is the culprit though I haven't pulled it down to test locally. But testing out keyboard events with the following sample file indicates that firefox gives a `keyCode` of 0 for all key press events which is in keeping with the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode):

> The value of keypress event is different between browsers... Gecko sets 0 if the pressed key is a printable key, otherwise it sets the same keyCode as a keydown or keyup event.

MDN suggests using `event.key` instead. Testing the space keypress event shows the latest chrome, firefox, safari and edge all give an `event.key` of `" "` while IE11 gives `"Spacebar"`. So I'm hoping this will do the job and give me my browser shortcuts back.

```html
<!DOCTYPE html>
<html>
    <body>
        <div><strong>code:</strong> <span id="code">not set</span></div>
        <div><strong>key:</strong> "<span id="key">not set</span>"</div>
        <div><strong>keyCode:</strong> <span id="keyCode">not set</span></div>
        <div><strong>charCode:</strong> <span id="charCode">not set</span></div>
        <script>
            document.addEventListener('keypress', function(e) {
                console.log(e); 
                document.getElementById('code').innerHTML = e.code;
                document.getElementById('key').innerHTML = e.key;
                document.getElementById('keyCode').innerHTML = e.keyCode;
                document.getElementById('charCode').innerHTML = e.charCode;
            })
        </script>
    </body>
</html>
```