### PR TITLE
API v2: remove unused endpoints and add /api/v2/cardviewer

### DIFF
--- a/common/cardname.py
+++ b/common/cardname.py
@@ -1,5 +1,7 @@
 import re
 
+from common.postgres import escape_like
+
 re_specialchars = re.compile(r"[ \-'\",:!?.()\u00ae&/\u2019]")
 LETTERS_MAP = {
 	'\u00e0': 'a',
@@ -42,3 +44,6 @@ def clean_text(text):
 	for k, v in LETTERS_MAP.items():
 		text = text.replace(k, v)
 	return text
+
+def to_query(text):
+	return "%" + "%".join(escape_like(clean_text(word)) for word in text.split()) + "%"

--- a/eventserver.py
+++ b/eventserver.py
@@ -144,8 +144,8 @@ async def main(loop):
 	server = Server()
 	await server.start(config['eventsocket'], config['event_port'])
 	app = aiohttp.web.Application()
-	app.router.add_route('GET', '/notifications/events', server.negotiate)
-	app.router.add_route('OPTIONS', '/notifications/events', server.cors_preflight)
+	app.router.add_route('GET', '/api/v2/events', server.negotiate)
+	app.router.add_route('OPTIONS', '/api/v2/events', server.cors_preflight)
 	app.on_shutdown.append(server.on_shutdown)
 
 	handler = app.make_handler()

--- a/lrrbot/main.py
+++ b/lrrbot/main.py
@@ -99,9 +99,6 @@ class LRRBot(irc.bot.SingleServerIRCBot):
 		else:
 			self.whisperconn = None
 
-		# create pubnub listener
-		self.cardviewer = cardviewer.CardViewer(self, self.loop)
-
 		# IRC event handlers
 		self.reactor.add_global_handler('welcome', self.check_privmsg_wrapper, 0)
 		self.reactor.add_global_handler('welcome', self.on_connect, 1)
@@ -128,6 +125,9 @@ class LRRBot(irc.bot.SingleServerIRCBot):
 		self.spammers = {}
 
 		self.rpc_server = rpc.Server(self, loop)
+
+		# create pubnub listener
+		self.cardviewer = cardviewer.CardViewer(self, self.loop)
 
 		self.commands = command_parser.CommandParser(self, loop)
 		self.command = self.commands.decorator

--- a/lrrbot/rpc.py
+++ b/lrrbot/rpc.py
@@ -21,13 +21,14 @@ import lrrbot.docstring
 log = logging.getLogger('serverevents')
 
 class Server(common.rpc.Server):
-	router = aiomas.rpc.Service(['explain', 'link_spam', 'spam', 'static'])
+	router = aiomas.rpc.Service(['cardviewer', 'explain', 'link_spam', 'spam', 'static'])
 
 	def __init__(self, lrrbot, loop):
 		super().__init__()
 		self.lrrbot = lrrbot
 		self.loop = loop
 
+		self.cardviewer = None
 		self.explain = None
 		self.link_spam = None
 		self.spam = None

--- a/webserver.py
+++ b/webserver.py
@@ -17,6 +17,7 @@ import www.commands
 import www.spam
 import www.history
 import www.api
+import www.api_v2
 import www.quotes
 import www.patreon
 import www.clips
@@ -34,6 +35,8 @@ app.jinja_env.globals["min"] = min
 app.jinja_env.globals["max"] = max
 app.jinja_env.globals["static_url"] = www.utils.static_url
 app.jinja_env.globals["cycler"] = www.utils.CyclerExt
+
+app.register_blueprint(www.api_v2.blueprint, url_prefix="/api/v2")
 
 __all__ = ['app']
 

--- a/www/api_v2.py
+++ b/www/api_v2.py
@@ -1,0 +1,186 @@
+import asyncio
+import sqlalchemy
+from www import server
+from www import login
+from common.config import config
+import common.rpc
+import datetime
+import pytz
+import flask
+import common.storm
+from common import googlecalendar
+import functools
+import urllib.parse
+from common import cardname
+from common.postgres import escape_like
+from flaskext.csrf import csrf_exempt
+
+def require_mod(func):
+	@functools.wraps(func)
+	async def wrapper(*args, **kwargs):
+		session = await login.load_session(include_url=False, include_header=False)
+		kwargs['session'] = session
+		if session['user']['is_mod']:
+			return await asyncio.coroutine(func)(*args, **kwargs)
+		else:
+			return flask.jsonify(message="%s is not a mod" % (session['user']['display_name'], )), 403
+	return wrapper
+
+blueprint = flask.Blueprint("api_v2", __name__)
+
+@blueprint.route("/")
+@login.with_session
+async def docs(session):
+	shows = server.db.metadata.tables["shows"]
+	with server.db.engine.begin() as conn:
+		shows = list(conn.execute(sqlalchemy.select([shows.c.string_id, shows.c.name]).where(shows.c.string_id != "").order_by(shows.c.string_id)))
+
+	return flask.render_template("api_v2_docs.html", session=session,
+		stormcount=stormcount().get_data().decode(),
+		tweet=await get_tweet(),
+		shows=shows,
+	)
+
+@blueprint.route("/stormcount")
+def stormcount():
+	return flask.jsonify({
+		'twitch-subscription': common.storm.get(server.db.engine, server.db.metadata, 'twitch-subscription'),
+		'twitch-resubscription': common.storm.get(server.db.engine, server.db.metadata, 'twitch-resubscription'),
+		'twitch-follow': common.storm.get(server.db.engine, server.db.metadata, 'twitch-follow'),
+		'twitch-cheer': common.storm.get(server.db.engine, server.db.metadata, 'twitch-cheer'),
+		'patreon-pledge': common.storm.get(server.db.engine, server.db.metadata, 'patreon-pledge'),
+	})
+
+@blueprint.route("/show", methods=["PUT"])
+@require_mod
+async def set_show(session):
+	if not flask.request.is_json or 'code' not in flask.request.get_json():
+		return flask.jsonify(message="Request not JSON"), 400
+	show = flask.request.get_json()['code']
+	await common.rpc.bot.set_show(show)
+	show_id = await common.rpc.bot.get_show_id()
+
+	shows = server.db.metadata.tables["shows"]
+	with server.db.engine.begin() as conn:
+		code, name = conn.execute(sqlalchemy.select([shows.c.string_id, shows.c.name]).where(shows.c.id == show_id)).first()
+		return flask.jsonify(
+			code=code,
+			name=name,
+		)
+
+@blueprint.route("/tweet")
+async def get_tweet():
+	return await common.rpc.bot.get_tweet()
+
+@blueprint.route("/disconnect", methods=["POST"])
+@csrf_exempt
+@require_mod
+async def disconnect(session):
+	await common.rpc.bot.disconnect_from_chat()
+	return '', 204
+
+# Implemented in `eventserver.py`
+@blueprint.route("/events")
+async def events():
+	if server.app.debug:
+		return flask.redirect("http://localhost:8080/api/v2/events?" + urllib.parse.urlencode(flask.request.args))
+	else:
+		return flask.jsonify(message="Server not set up correctly."), 500
+
+CLIP_URL = "https://clips.twitch.tv/{}"
+@blueprint.route("/clips")
+@require_mod
+async def get_clips(session):
+	days = float(flask.request.values.get('days', 14))
+	startdt = datetime.datetime.now(pytz.UTC) - datetime.timedelta(days=days)
+	full = int(flask.request.values.get('full', 0))
+	clips = server.db.metadata.tables["clips"]
+	with server.db.engine.begin() as conn:
+		if full:
+			clipdata = conn.execute(sqlalchemy.select(
+				[clips.c.slug, clips.c.title, clips.c.vodid, clips.c.rating])
+				.where(clips.c.time >= startdt)
+				.where(clips.c.deleted == False)
+				.order_by(clips.c.time.asc())).fetchall()
+			clipdata = [
+				{
+					'slug': slug, 'title': title, 'vodid': vodid, 'rating': rating,
+					'url': CLIP_URL.format(slug),
+				}
+				for slug, title, vodid, rating in clipdata
+			]
+			return flask.jsonify(clipdata)
+		else:
+			clipdata = conn.execute(sqlalchemy.select([clips.c.slug])
+				.where(clips.c.rating == True)
+				.where(clips.c.time >= startdt)
+				.where(clips.c.deleted == False)
+				.order_by(clips.c.time.asc())).fetchall()
+			clipdata = "\n".join(CLIP_URL.format(slug) for slug, in clipdata)
+			return flask.wrappers.Response(clipdata, mimetype="text/plain")
+
+@blueprint.route("/polls")
+async def get_polls():
+	data = await common.rpc.bot.get_polls()
+	return flask.jsonify(data)
+
+@blueprint.route("/cardviewer", methods=["POST"])
+@csrf_exempt
+@require_mod
+async def cardviewer_announce(session):
+	if not flask.request.is_json:
+		return flask.jsonify(message="Request not JSON"), 400
+	
+	req = flask.request.get_json()
+
+	cards = server.db.metadata.tables['cards']
+	card_multiverse = server.db.metadata.tables['card_multiverse']
+
+	query = sqlalchemy.select([cards.c.id, cards.c.name, cards.c.text])
+
+	if 'multiverseid' in req:
+		query = query.select_from(cards.join(card_multiverse)).where(card_multiverse.c.id == req['multiverseid'])
+	elif 'name' in req:
+		name = cardname.to_query(req['name'])
+		exact = cardname.clean_text(req['name'])
+		hidden = False
+		if 'variant' in req:
+			name += escape_like("_" + req['variant'])
+			exact += "_" + req['variant']
+			hidden = True
+
+		exact_query = sqlalchemy.exists().where(cards.c.filteredname == exact)
+		if not hidden:
+			exact_query = exact_query.where(~cards.c.hidden)
+
+		query = query.where(
+			(exact_query & (cards.c.filteredname == exact))
+				| (~exact_query & cards.c.filteredname.ilike(name)))
+		if not hidden:
+			query = query.where(~cards.c.hidden)
+	elif 'host' in req or 'augment' in req:
+		name = ""
+		if 'augment' in req:
+			name += cardname.to_query(req['augment']) + escape_like("_aug")
+		if 'host' in req:
+			name += ("_" if name != "" else "") + cardname.to_query(req['host']) + escape_like("_host")
+		query = query.where(cards.c.filteredname.ilike(name))
+	else:
+		return flask.jsonify(message=""), 400
+
+	with server.db.engine.begin() as conn:
+		cards = conn.execute(query).fetchall()
+
+	if len(cards) == 0:
+		return flask.jsonify(message="No such card"), 400
+	elif len(cards) > 1:
+		return flask.jsonify(message="Matched multiple cards"), 400
+
+	card_id, name, text = cards[0]
+
+	await common.rpc.bot.cardviewer.announce(card_id)
+
+	return flask.jsonify(
+		name=name,
+		text=text,
+	)

--- a/www/notifications.py
+++ b/www/notifications.py
@@ -56,11 +56,6 @@ def get_milestones():
 def notifications(session):
 	last_event_id, events = get_events()
 
-	if server.app.debug:
-		eventserver_root = "http://localhost:8080"
-	else:
-		eventserver_root = ""
-
 	patreon_users = server.db.metadata.tables['patreon_users']
 	users = server.db.metadata.tables['users']
 	with server.db.engine.begin() as conn:
@@ -71,4 +66,9 @@ def notifications(session):
 	if name:
 		name = name[0]
 
-	return flask.render_template('notifications.html', events=events, last_event_id=last_event_id, eventserver_root=eventserver_root, session=session, patreon_creator_name=name, milestones=get_milestones())
+	return flask.render_template('notifications.html', events=events, last_event_id=last_event_id, session=session, patreon_creator_name=name, milestones=get_milestones())
+
+# Compatibility shim
+@server.app.route('/notifications/events')
+def events():
+	return flask.redirect(flask.url_for("api_v2.events", **flask.request.args), 301)

--- a/www/static/notifications.js
+++ b/www/static/notifications.js
@@ -8,7 +8,7 @@ window.addEventListener('DOMContentLoaded', function (event) {
 	}
 
 	if (window.EventSource) {
-		var stream = new EventSource(window.EVENTSERVER_ROOT + "/notifications/events?last-event-id=" + window.last_event_id);
+		var stream = new EventSource("/api/v2/events?last-event-id=" + window.last_event_id);
 		stream.addEventListener("twitch-subscription", function (event) {
 			twitch_subscription(JSON.parse(event.data));
 			update_title();
@@ -68,7 +68,7 @@ function ajax_poll() {
 		});
 		update_title();
 	})
-	req.open("GET", window.EVENTSERVER_ROOT + "/notifications/events?last-event-id=" + window.last_event_id);
+	req.open("GET", "/api/v2/events?last-event-id=" + window.last_event_id);
 	req.setRequestHeader("Accept", "application/json");
 	req.send();
 }

--- a/www/templates/api_v2_docs.html
+++ b/www/templates/api_v2_docs.html
@@ -1,0 +1,429 @@
+{% extends "master.html" %}
+
+{% block title %}LRRbot API v2 documentation{% endblock %}
+
+{% block header %}LRRbot API v2 documentation{% endblock %}
+
+{% block content %}
+<h2>Table of contents</h2>
+<ul>
+	<li><a href="#cardviewer_announce"><code>POST {{ url_for("api_v2.cardviewer_announce") }}</code></a></li>
+	<li><a href="#get_clips"><code>GET {{ url_for("api_v2.get_clips") }}</code></a></li>
+	<li><a href="#disconnect"><code>POST {{ url_for("api_v2.disconnect") }}</code></a></li>
+	<li><a href="#events"><code>GET {{ url_for("api_v2.events") }}</code></a></li>
+	<li><a href="#get_polls"><code>GET {{ url_for("api_v2.get_polls") }}</code></a></li>
+	<li><a href="#set_show"><code>PUT {{ url_for("api_v2.set_show") }}</code></a></li>
+	<li><a href="#stormcount"><code>GET {{ url_for("api_v2.stormcount") }}</code></a></li>
+	<li><a href="#get_tweet"><code>GET {{ url_for("api_v2.get_tweet") }}</code></a></li>
+</ul>
+
+<h2 id="cardviewer_announce"><code>POST {{ url_for("api_v2.cardviewer_announce") }}</code></h2>
+<p>
+	Announce an MTG card in chat. If multiple modes would match the query the first one is used. For example
+	the query <code>{"multiverseid": 1, "name": "Lighning Bolt"}</code> would announce the card Ankh of Mishra.
+</p>
+<h3>By multiverse ID</h3>
+<dl>
+	<dt><code>multiverseid</code></dt>
+	<dd>The ID of the card on Gatherer.</dd>
+</dl>
+<h4>Example</h4>
+<pre>{"multiverseid": 435173}</pre>
+<h3>By name</h3>
+<dl>
+	<dt><code>name</code></dt>
+	<dd>Name of the card.</dd>
+	<dt><code>variant</code></dt>
+	<dd>Optional. Card variant code if there's multiple cards with the same name.</dd>
+</dl>
+<h4>Examples</h4>
+<pre>{"name": "Strip Mine"}
+{"name": "Adanto, the First Fort"}
+{"name": "Very Cryptic Command", "variant": "c"}</pre>
+<h3>Host and augment</h3>
+<dl>
+	<dt><code>host</code></dt>
+	<dd>The name of the host creature.</dd>
+	<dt><code>augment</code></dt>
+	<dd>The name of the augment creature.</dd>
+</dl>
+<h4>Example</h4>
+<pre>{"augment": "Half-Kitten, Half-", "host": "Adorable Kitten"}</pre>
+
+<h3>Response</h3>
+On success it will respond with the name and the text of the card.
+<pre>{
+  "name": "Llanowar Elves",
+  "text": "Llanowar Elves [G] | Creature — Elf Druid [1/1] | {T}: Add {G} to your mana pool."
+}</pre>
+
+<h2 id="get_clips"><code>GET {{ url_for("api_v2.get_clips") }}</code></h2>
+<p>Get the list of clips. The user must me a moderator.</p>
+
+<h3>Query parameters</h3>
+<dl>
+	<dt><code>days</code></dt>
+	<dd>Return clips that are up to <code>days</code> days old. The default is 14.</dd>
+	<dt><code>full</code></dt>
+	<dd>If zero (the default) then return all accepted clips as URLs one per line.</dd>
+	<dd>If non-zero then return all clips as JSON.</dd>
+	<dd>
+		<dl>
+			<dt><code>rating</code></dt>
+			<dd><code>true</code> if the clip was accepted, <code>false</code> if it wasn't.</dd>
+			<dt><code>slug</code></dt>
+			<dd>The URL slug of the clip.</dd>
+			<dt><code>title</code></dt>
+			<dd>The title of the clip.</dd>
+			<dt><code>url</code></dt>
+			<dd>The URL of the clip.</dd>
+			<dt><code>vodid</code></dt>
+			<dd>The ID of the video the clip is taken from.</dd>
+		</dl>
+	</dd>
+</dl>
+
+<h3>Example response</h3>
+<h4><code>full=0</code></h4>
+<pre>https://clips.twitch.tv/TolerantDirtyFishKreygasm
+https://clips.twitch.tv/WrongUnusualSparrowOhMyDog
+https://clips.twitch.tv/DeadEnergeticWeaselBCWarrior</pre>
+
+<h4><code>full=1</code></h4>
+<pre>[
+  {
+    "rating": false, 
+    "slug": "VibrantPiercingRuffMrDestructoid", 
+    "title": "the Steam dalay", 
+    "url": "https://clips.twitch.tv/VibrantPiercingRuffMrDestructoid", 
+    "vodid": "238399552"
+  }
+]</pre>
+
+<h2 id="disconnect"><code>POST {{ url_for("api_v2.disconnect") }}</code></h2>
+<p>Disconnects the bot from Twitch. Returns nothing. The user must be a moderator.</p>
+
+<h2 id="events"><code>GET {{ url_for("api_v2.events") }}</code></h2>
+<p>Get all events after a certain event. This endpoint uses content negotiation to determine how it behaves.</p>
+
+<h3>Filter parameters</h3>
+<p>If no filter parameters are set only new events will be returned.</p>
+
+<dl>
+	<dt><code>last-event-id</code></dt>
+	<dd>Only include events after this one. Can also be set as the <code>Last-Event-ID</code> header. If both are present the header is used.</dd>
+	<dt><code>interval</code></dt>
+	<dd>Only include events that happened up to <code>interval</code> ago.
+		The syntax is whatever <a href="https://www.postgresql.org/docs/10/static/datatype-datetime.html#DATATYPE-INTERVAL-INPUT">PostgreSQL accepts.</a></dd>
+</dl>
+
+<h3>Events</h3>
+<h4>Common fields</h4>
+<dl>
+	<dt><code>count</code></dt>
+	<dl>The value of the corresponding stormcount. In general how many events of the same type as this event have occurred today. Is not present on all event types.</dl>
+	<dt><code>time</code></dt>
+	<dt>Timestamp of the event in the ISO 8601 format.</dt>
+</dl>
+
+<h4><code>patreon-pledge</code></h4>
+<p>New patron on Patreon.</p>
+<dl>
+	<dt><code>name</code></dt>
+	<dd>Name used in the announcement. Twitch name if it's known, Patreon name otherwise.</dd>
+	<dt><code>patreon</code></dt>
+	<dd>Patreon specific information</dd>
+	<dd>
+		<dl>
+			<dt><code>full_name</code></dt>
+			<dd>Patron full name</dd>
+			<dt><code>avatar</code></dt>
+			<dd>Avatar. Might be missing or <code>null</code>.</dd>
+			<dt><code>url</code></dt>
+			<dd>Patron's Patreon page</dd>
+		</dl>	
+	</dd>
+	<dt><code>twitch</code></dt>
+	<dd>Twitch specific information. Might be not present or <code>null</code>.</dd>
+	<dd>
+		<dl>
+			<dt><code>name</code></dt>
+			<dd>Patron's Twitch name.</dd>
+		</dl>
+	</dd>
+</dl>
+<h5>Example payload</h5>
+<pre>{
+  "name": "qrpth",
+  "twitch": {
+    "name": "qrpth"
+  },
+  "patreon": {
+    "avatar": "//s3-us-west-1.amazonaws.com/patreon.user/wyI1P8QgKYucgLGoHwDqE2ezldUBSDHk5eAxNRzYr7psZarMizNwlEhCPDM41gIa_large_2.jpeg",
+    "full_name": "qrpth",
+    "url": "https://www.patreon.com/qrpth"
+  },
+  "time": "2016-06-20T21:17:09.890668+02:00",
+  "count": 1
+}</pre>
+
+<h4><code>strawpoll-add</code></h4>
+<p>
+	New poll was added with <kbd>!poll</kbd> or <kbd>!nowkiss</kbd>. The payload is the same as returned by
+	<a href="https://strawpoll.me/">strawpoll.me's</a> <a href="https://github.com/strawpoll/strawpoll/wiki/API">API</a>.
+	The only difference is the <code>tag</code> key which if present and equal to <code>"nowkiss"</code> means that the
+	poll was created with <kbd>!nowkiss</kbd>.
+</p>
+<h5>Example payload</h5>
+<pre>{
+  "id": 15346267,
+  "title": "Keep playing Hustle Cat? [2018-03-23]",
+  "time": "2018-03-23T20:03:36.540677+01:00",
+  "options": [
+    "Swipe Right (keep playing next week)",
+    "Swipe Left (new game!)"
+  ],
+  "captcha": false,
+  "dupcheck": "normal",
+  "votes": [
+    0,
+    0
+  ],
+  "multi": false,
+  "tag": "nowkiss"
+}</pre>
+
+<h4><code>strawpoll-complete</code></h4>
+<p>
+	A poll has completed and the results have been announced in chat. The payload is the same as returned by
+	<a href="https://strawpoll.me/">strawpoll.me's</a> <a href="https://github.com/strawpoll/strawpoll/wiki/API">API</a>.
+	The only difference is the <code>tag</code> key which if present and equal to <code>"nowkiss"</code> means that the
+	poll was created with <kbd>!nowkiss</kbd>.
+</p>
+<h5>Example payload</h5>
+<pre>{
+  "id": 15346267,
+  "title": "Keep playing Hustle Cat? [2018-03-23]",
+  "time": "2018-03-23T20:08:41.598222+01:00",
+  "options": [
+    "Swipe Right (keep playing next week)",
+    "Swipe Left (new game!)"
+  ],
+  "captcha": false,
+  "dupcheck": "normal",
+  "votes": [
+    90,
+    5
+  ],
+  "multi": false,
+  "tag": "nowkiss"
+}</pre>
+
+<h4><code>stream-down</code></h4>
+<p>The stream has stopped.</p>
+<h5>Example payload</h5>
+<pre>{
+  "time": "2018-03-27T01:59:55.636950+02:00"
+}</pre>
+
+<h4><code>stream-up</code></h4>
+<p>The stream has started.</p>
+<h5>Example payload</h5>
+<pre>{
+  "time": "2018-03-27T01:59:55.636950+02:00"
+}</pre>
+
+<h4><code>twitch-follow</code></h4>
+<p>New follower on Twitch.</p>
+<dl>
+	<dt><code>name</code></dt>
+	<dd>Name</dd>
+	<dt><code>avatar</code></dt>
+	<dd>Avatar</dd>
+</dl>
+
+<h5>Example payload</h5>
+<pre>{
+  "name": "qrpth",
+  "avatar": "https://static-cdn.jtvnw.net/jtv_user_pictures/qrpth-profile_image-d43b8ad66411f7a4-300x300.png",
+  "time": "2016-07-21T19:54:30+02:00",
+  "count": 7
+}</pre>
+
+<h4><code>twitch-message</code></h4>
+<p>New message from Twitch. Used to be sent to say the number of people that subscribed since the last stream.</p>
+
+<dl>
+	<dt><code>message</code></dt>
+	<dd>The message.</dd>
+</dl>
+
+<h5>Example payload</h5>
+<pre>{
+  "message": "23 viewers resubscribed while you were away!",
+  "time": "2017-05-24T18:07:59.674772+02:00",
+  "count": 1
+}</pre>
+
+<h4><code>twitch-resubscription</code></h4>
+<p>New returning subscriber on Twitch.</p>
+
+<dl>
+	<dt><code>name</code></dt>
+	<dd>Name</dd>
+	<dt><code>avatar</code></dt>
+	<dd>Avatar. Might be not present or <code>null</code>.</dd>
+	<dt><code>benefactor</code></dt>
+	<dd>The name of the user who gifted this subscription. Might be <code>null</code> or missing.</dd>
+	<dt><code>monthcount</code></dt>
+	<dd></dd>
+	<dt><code>message</code></dt>
+	<dd>The plaintext subscription message. Might be <code>null</code> or missing.</dd>
+	<dt><code>messagehtml</code></dt>
+	<dd>The subscription message as HTML. Might be <code>null</code> or missing.</dd>
+</dl>
+
+<h5>Example payload</h5>
+<pre>{
+  "benefactor": null,
+  "name": "qrpth",
+  "monthcount": 23,
+  "time": "2018-03-16T22:18:43.166609+01:00",
+  "count": 30,
+  "avatar": "https://static-cdn.jtvnw.net/jtv_user_pictures/qrpth-profile_image-d43b8ad66411f7a4-300x300.png",
+  "message": "lrrHORN lrrHORN lrrHEART",
+  "messagehtml": "&lt;img src=\"https://static-cdn.jtvnw.net/emoticons/v1/44650/1.0\" alt=\"lrrHORN\" title=\"lrrHORN\"> &lt;img src=\"https://static-cdn.jtvnw.net/emoticons/v1/44650/1.0\" alt=\"lrrHORN\" title=\"lrrHORN\"> &lgt;img src=\"https://static-cdn.jtvnw.net/emoticons/v1/325892/1.0\" alt=\"lrrHEART\" title=\"lrrHEART\">"
+}</pre>
+
+<h4><code>twitch-subscription</code></h4>
+<p>New subscriber on Twitch.</p>
+
+<dl>
+	<dt><code>name</code></dt>
+	<dd>Name</dd>
+	<dt><code>avatar</code></dt>
+	<dd>Avatar. Might be not present or <code>null</code>.</dd>
+	<dt><code>benefactor</code></dt>
+	<dd>The name of the user who gifted this subscription. Might be <code>null</code> or missing.</dd>
+</dl>
+
+<h5>Example payload</h5>
+<pre>{
+  "name": "rourke9",
+  "avatar": "https://static-cdn.jtvnw.net/user-default-pictures/49988c7b-57bc-4dee-bd4f-6df4ad215d3a-profile_image-300x300.jpg",
+  "benefactor": "F1SHOR",
+  "time": "2018-03-25T03:45:05.509759+02:00",
+  "count": 12
+}</pre>
+
+<h3>Server-sent events mode (default)</h3>
+<h4>Example request</h4>
+<pre>curl -H "Accept: text/event-stream" {{ url_for("api_v2.events", _external=True) }}</pre>
+<h4>Example response</h4>
+<pre>id:102985
+event:stream-up
+data:{"time": "2018-03-27T20:59:04.621308+02:00"}
+
+:keep-alive
+
+...</pre>
+
+<h3>JSON mode</h3>
+<p>Will only return old events. Thus if no filter parameter is set this will return an empty list</p>
+<h4>Example request</h4>
+<pre>curl -H "Accept: application/json" {{ url_for("api_v2.events", _external=True) }}</pre>
+<h4>Example response</h4>
+<pre>{
+  "events": [
+    {
+      "data": {
+        "time": "2018-03-27T20:59:04.621308+02:00"
+      },
+      "id": 102985,
+      "event": "stream-up"
+    }
+  ]
+}</pre>
+
+<h2 id="get_polls"><code>GET {{ url_for("api_v2.get_polls") }}</code></h2>
+<p>Get currently active polls.</p>
+
+<dl>
+	<dt><code>id</code></dt>
+	<dd><a href="https://strawpoll.me/">strawpoll.me</a> ID of the poll</dd>
+	<dt><code>title</code></dt>
+	<dd>The name of the poll</dd>
+	<dt><code>tag</code></dt>
+	<dd>If present and equal to <code>"nowkiss"</code> then the poll was created with <kbd>!nowkiss</kbd>.</dd>
+</dl>
+
+<h3>Example response</h3>
+<pre>[
+  {
+    "id": 15346267,
+    "title": "Keep playing Hustle Cat? [2018-03-23]",
+    "tag": "nowkiss"
+  }
+]</pre>
+
+<h2 id="set_show"><code>PUT {{ url_for("api_v2.set_show") }}</code></h2>
+<p>Set the current show. Returns the currently active show which might not be what was set. The user must be a moderator.</p>
+
+<dl>
+	<dt><code>code</code></dt>
+	<dd>The show code or empty string to unset the show.</dd>
+	<dd>
+		<table class="nicetable">
+			<thead>
+				<tr><th>Code</th><th>Name</th></tr>
+			</thead>
+			<tbody>
+				{% for key, name in shows %}
+					<tr class="{{ loop.cycle('odd', 'even') }}">
+						<td><code>{{ key }}</code></td>
+						<td>{{ name }}</td>
+					</tr>
+				{% endfor %}
+			</tbody>
+		</table>
+	</dd>
+</dl>
+
+<h3>Example request</h3>
+<pre>curl -X PUT {{ url_for("api_v2.set_show", _external=True, apipass="dickbutt") }} -H "Content-Type: application/json" -d '{"code": "tinker"}'</pre>
+
+<h3>Example response</h3>
+<pre>{
+  "code": "tinker", 
+  "name": "Tinker, Tailor, Solder, Fry"
+}</pre>
+
+<h2 id="stormcount"><code>GET {{ url_for("api_v2.stormcount") }}</code></h2>
+<p>Get today's stormcounts.</p>
+
+<dl>
+	<dt><code>patreon-pledge</code></dt>
+	<dd>The number of new patrons on Patreon.</dd>
+
+	<dt><code>twitch-cheer</code></dt>
+	<dd>The total number of bits cheered.</dd>
+
+	<dt><code>twitch-follow</code></dt>
+	<dd>The number of new followers.</dd>
+
+	<dt><code>twitch-resubscription</code></dt>
+	<dd>The number of returning subscribers.</dd>
+
+	<dt><code>twitch-subscription</code></dt>
+	<dd>The number of new subscribers.</dd>
+</dl>
+
+<h3>Example response</h3>
+<pre>{{ stormcount }}</pre>
+
+<h2 id="get_tweet"><code>GET {{ url_for("api_v2.get_tweet") }}</code></h2>
+<p>Get a random message to post on <a href="https://twitter.com/lrrbot">LRRbot's Twitter account</a>.</p>
+<h3>Example response</h3>
+<pre>{{ tweet }}</pre>
+
+{% endblock %}

--- a/www/templates/notifications.html
+++ b/www/templates/notifications.html
@@ -5,7 +5,6 @@
 <script type="text/javascript" src="{{static_url('notifications.js')|e}}"></script>
 <script>
 	window.last_event_id = {{ last_event_id | tojson }};
-	window.EVENTSERVER_ROOT = {{ eventserver_root | tojson }};
 	window.PATREON_CREATOR_NAME = {{ patreon_creator_name | tojson }};
 </script>
 {%endblock%}


### PR DESCRIPTION
v1 still exists and will be removed when LRR stops using it.

Removed in v2:
 * `GET /next`
 * `GET /game`
 * `GET /show`

Different in v2:
 * `GET /show/<name>` is now `PUT /show`.
 * `GET /disconnect` is now `POST /disconnect`.
 * `GET /tweet` no longer requires a moderator.
 * The notification events endpoint (`/notifications/events`) is now part of the API. For now a redirect is in place that will be removed with the v1 API.

New in v2:
 * `POST /cardviewer`: replacement for PubNub.

Documentation: https://lrrbot.mrphlip.com/api/v2/

cc: @paul-lrr