### PR TITLE
Fix doubled stream go-live announcements

### DIFF
--- a/lrrbot/stream_status.py
+++ b/lrrbot/stream_status.py
@@ -12,14 +12,22 @@ class StreamStatus:
 		self.lrrbot = lrrbot
 		self.loop = loop
 
-		self.handle = self.loop.call_later(twitch.GAME_CHECK_INTERVAL, self.schedule)
+		self.handle = None
 		self.was_live = bool(twitch.is_stream_live())
-
-	def reschedule(self):
-		self.handle.cancel()
 		self.schedule()
 
+	def reschedule(self):
+		if self.handle is not None:
+			self.handle.cancel()
+			self.handle = None
+		self.start_check_stream()
+
 	def schedule(self):
+		if self.handle is None:
+			self.handle = self.loop.call_later(twitch.GAME_CHECK_INTERVAL, self.start_check_stream)
+
+	def start_check_stream(self):
+		self.handle = None
 		asyncio.ensure_future(self.check_stream(), loop=self.loop).add_done_callback(utils.check_exception)
 
 	async def check_stream(self):
@@ -29,12 +37,12 @@ class StreamStatus:
 
 		if is_live and not self.was_live:
 			log.debug("Stream is now live")
+			self.was_live = True
 			await rpc.eventserver.event('stream-up', {}, None)
 			await rpc.eris.announcements.stream_up(data)
 		elif not is_live and self.was_live:
 			log.debug("Stream is now offline")
+			self.was_live = False
 			await rpc.eventserver.event('stream-down', {}, None)
 
-		self.was_live = is_live
-
-		self.handle = self.loop.call_later(twitch.GAME_CHECK_INTERVAL, self.schedule)
+		self.schedule()


### PR DESCRIPTION
The stream-status processing could get doubled if `reschedule` was
called while `check_stream` was running (eg if it was called twice in
quick succession). Then if `check_stream` runs while another instance of
`check_stream` was `await`ing sending a message (between checking the
stream status and updating `was_live`) then both of them could send the
gone-live announcement to Discord. And they'd both schedule another
instance so it will keep happening.

Add extra handling so only one `check_stream` should ever be scheduled,
and make sure that even if `check_stream` is called twice at once, we
update `was_live` before `await`ing so that only one message should be
sent.