### PR TITLE
Store the bot state in the database

### DIFF
--- a/lrrbot/commands/strawpoll.py
+++ b/lrrbot/commands/strawpoll.py
@@ -59,7 +59,7 @@ def polls(lrrbot, conn, event, respond_to):
 
 	List all currently active polls.
 	"""
-	if lrrbot.polls == []:
+	if not lrrbot.polls:
 		return conn.privmsg(respond_to, "No active polls.")
 	now = time.time()
 	messages = []
@@ -102,7 +102,9 @@ async def new_poll(lrrbot, conn, event, respond_to, multi, timeout, poll_id, tit
 	else:
 		timeout = DEFAULT_TIMEOUT
 	end = time.time() + int(timeout)
-	lrrbot.polls += [(end, title, poll_id, respond_to, tag)]
+	# NB: need to assign to lrrbot.polls, rather than using lrrbot.polls.append,
+	# so that the state change gets saved properly
+	lrrbot.polls = lrrbot.polls + [(end, title, poll_id, respond_to, tag)]
 	conn.privmsg(respond_to, "New poll: %s (https://www.strawpoll.me/%s%s): %s from now" % (title, poll_id, space.SPACE, common.time.nice_duration(timeout, 1)))
 
 	if tag is not None:

--- a/lrrbot/main.py
+++ b/lrrbot/main.py
@@ -16,6 +16,7 @@ from common import FRAMEWORK_ONLY
 from common import game_data
 from common import postgres
 from common import slack
+from common import state
 from common import twitch
 from common import utils
 from common.config import config
@@ -46,6 +47,13 @@ log = logging.getLogger('lrrbot')
 SELF_METADATA = {'specialuser': {'mod', 'subscriber'}, 'usercolor': '#FF0000', 'emoteset': {317}}
 
 class LRRBot(irc.bot.SingleServerIRCBot):
+	game_override = state.Property("lrrbot.main.game_override")
+	show_override = state.Property("lrrbot.main.show_override")
+	access = state.Property("lrrbot.main.access", "all")
+	show_id = state.Property("lrrbot.main.show_id")
+	polls = state.Property("lrrbot.main.polls", [])
+	cardview = state.Property("lrrbot.main.cardview", False)
+
 	def __init__(self, loop):
 		self.engine, self.metadata = postgres.get_engine_and_metadata()
 		users = self.metadata.tables["users"]
@@ -115,12 +123,8 @@ class LRRBot(irc.bot.SingleServerIRCBot):
 			self.whisperconn.add_whisper_handler(self.on_whisper_received)
 
 		# Set up bot state
-		self.game_override = None
-		self.show_override = None
-		self.access = "all"
-		self.set_show("")
-		self.polls = []
-		self.cardview = False
+		if self.show_id is None:
+			self.set_show("")
 
 		self.spammers = {}
 


### PR DESCRIPTION
Uses the [descriptor protocol](https://docs.python.org/3/howto/descriptor.html) to convert field accesses into database queries.

My only concern is that this is too magical because it masquerades potentially expensive database queries as cheap field accesses. But `SELECT value FROM state WHERE key = $0` should be fast and the database is on the same node. A way to lessen the impact of that would be to add a simple write-through cache but I'm not completely sure it's necessary.

`spammers` should be exempt because spam bots tend to only get hit once.

Closes #153.