### PR TITLE
Add more details on dependencies to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Things not covered: `keys.json` for `!highlight`, tokens and secrets for Patreon
 
  1. These commands assume Ubuntu 16.10 and that you're using Bash as your shell. Adapt as needed.
 	
-	Currently lrrbot works with postgresql >= 9.5 and python >= 3.5 and < 3.7, if the exact versions in the command below are unavailable on your operating system.
+	Currently LRRbot works with PostgreSQL >= 9.5 and Python >= 3.5 and < 3.7, if the exact versions in the command below are unavailable on your operating system.
     ```
     sudo apt-get install git postgresql-9.5 postgresql-server-dev-9.5 python3.5-dev virtualenv build-essential
     git clone git@github.com:mrphlip/lrrbot

--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ LRRbot contains modules that aren't licensed under Apache-2.0:
 ### Linux (Ubuntu 16.10)
 Things not covered: `keys.json` for `!highlight`, tokens and secrets for Patreon integration, Slack integration.
 
- 1. These commands assume Ubuntu 16.10 and that you're using Bash as your shell. Adapt as needed.  
+ 1. These commands assume Ubuntu 16.10 and that you're using Bash as your shell. Adapt as needed.
+	
+	Currently lrrbot works with postgresql >= 9.5 and python >= 3.5 and < 3.7, if the exact versions in the command below are unavailable on your operating system.
     ```
     sudo apt-get install git postgresql-9.5 postgresql-server-dev-9.5 python3.5-dev virtualenv build-essential
     git clone git@github.com:mrphlip/lrrbot


### PR DESCRIPTION
Ubuntu 16.10 EOL'ed over a year ago, so the exact instructions are a bit difficult to follow.  Version numbers taken from discussion in Discord, but I didn't test against them before adding the information.