### PR TITLE
Speed up MTGJSON processing 12 times

### DIFF
--- a/alembic/versions/dd3efe83691d_drop_card_collector.py
+++ b/alembic/versions/dd3efe83691d_drop_card_collector.py
@@ -1,0 +1,20 @@
+revision = 'dd3efe83691d'
+down_revision = '7f56063682aa'
+branch_labels = None
+depends_on = None
+
+import alembic
+import sqlalchemy
+
+def upgrade():
+	alembic.op.drop_table('card_collector')
+
+def downgrade():
+	alembic.op.create_table(
+		"card_collector",
+		sqlalchemy.Column("setid", sqlalchemy.String(10), nullable=False),
+		sqlalchemy.Column("collector", sqlalchemy.String(10), nullable=False),
+		sqlalchemy.Column("cardid", sqlalchemy.Integer, sqlalchemy.ForeignKey("cards.id", ondelete="CASCADE"), nullable=False),
+	)
+	alembic.op.create_primary_key(None, "card_collector", ["setid", "collector"])
+	alembic.op.create_index('card_collector_cardid_idx', 'card_collector', ['cardid'])

--- a/alembic/versions/ee81e255ddc0_drop_cards_lastprinted.py
+++ b/alembic/versions/ee81e255ddc0_drop_cards_lastprinted.py
@@ -1,0 +1,13 @@
+revision = 'ee81e255ddc0'
+down_revision = 'dd3efe83691d'
+branch_labels = None
+depends_on = None
+
+import alembic
+import sqlalchemy
+
+def upgrade():
+	alembic.op.drop_column('cards', 'lastprinted')
+
+def downgrade():
+	alembic.op.add_column('cards', sqlalchemy.Column("lastprinted", sqlalchemy.Date))

--- a/common/http.py
+++ b/common/http.py
@@ -13,6 +13,8 @@ from common import utils
 
 log = logging.getLogger("common.http")
 
+USER_AGENT = "LRRbot/2.0 (https://lrrbot.com/)"
+
 class Request(urllib.request.Request):
 	"""Override the get_method method of Request, adding the "method" field that doesn't exist until Python 3.3"""
 	def __init__(self, *args, method=None, **kwargs):
@@ -29,7 +31,7 @@ def request(url, data=None, method='GET', maxtries=3, headers=None, timeout=30, 
 	if headers is None:
 		headers = {}
 	# Let's be nice.
-	headers["User-Agent"] = "LRRbot/2.0 (https://lrrbot.com/)"
+	headers["User-Agent"] = USER_AGENT
 
 	if 'api.twitch.tv' in url and headers.get('Accept') != 'application/vnd.twitchtv.v5+json':
 		log.warning("Non-v5 request to: %r", url)
@@ -73,7 +75,7 @@ atexit.register(lambda: asyncio.get_event_loop().run_until_complete(http_request
 async def request_coro(url, data=None, method='GET', maxtries=3, headers=None, timeout=30, allow_redirects=True, asjson=False):
 	if headers is None:
 		headers = {}
-	headers["User-Agent"] = "LRRbot/2.0 (https://lrrbot.com/)"
+	headers["User-Agent"] = USER_AGENT
 
 	if 'api.twitch.tv' in url and headers.get('Accept') != 'application/vnd.twitchtv.v5+json':
 		log.warning("Non-v5 request to: %r", url)

--- a/lrrbot/commands/card.py
+++ b/lrrbot/commands/card.py
@@ -60,30 +60,6 @@ def real_card_lookup(lrrbot, conn, event, respond_to, search, noerror=False, inc
 
 def find_card(lrrbot, search, includehidden=False, game=CARD_GAME_MTG):
 	cards = lrrbot.metadata.tables["cards"]
-	card_multiverse = lrrbot.metadata.tables["card_multiverse"]
-	card_collector = lrrbot.metadata.tables["card_collector"]
-
-	if isinstance(search, int):
-		query = (sqlalchemy.select([cards.c.name, cards.c.text])
-						.select_from(card_multiverse.join(cards, cards.c.id == card_multiverse.c.cardid))
-						.where(card_multiverse.c.id == search))
-		if not includehidden:
-			query = query.where(cards.c.hidden == False)
-		if game is not None:
-			query = query.where(cards.c.game == game)
-		with lrrbot.engine.begin() as conn:
-			return conn.execute(query).fetchall()
-
-	if isinstance(search, tuple):
-		query = (sqlalchemy.select([cards.c.name, cards.c.text])
-						.select_from(card_collector.join(cards, cards.c.id == card_collector.c.cardid))
-						.where((card_collector.c.setid == search[0].lower()) & (card_collector.c.collector == search[1])))
-		if not includehidden:
-			query = query.where(cards.c.hidden == False)
-		if game is not None:
-			query = query.where(cards.c.game == game)
-		with lrrbot.engine.begin() as conn:
-			return conn.execute(query).fetchall()
 
 	cleansearch = clean_text(search)
 	with lrrbot.engine.begin() as conn:


### PR DESCRIPTION
For MTG every database query we do for every card adds about 12 seconds to the script's runtime.

* Process cards in a reverse chronological order
* Keep track of what cards have been processed already
* Drop collector numbers
* [MTG] Deduplicate multiverse IDs
* [MTG] Keep track of processed multiverse IDs because Throne of Eldraine is weird and has some cards twice. Something something `"frameEffects": ["showcase"]`.
* [MTG] use the best compression format that is supported by Python's standard library. Probably doesn't matter much but the XZ is half the size of the ZIP (21.7 MiB vs 43.4 MiB).
* [Keyforge] Swap out `common.http.request` for `requests`.
* [Keyforge] Retry throttled requests.

`build_carddb_mtg.py` now takes 23 seconds to run instead of a minute and 47 seconds. I didn't time `build_carddb_keyforge.py` because if it doesn't touch the network it's very fast anyway.