### PR TITLE
Add Lorcana card lookup

### DIFF
--- a/build_carddb_lorcana.py
+++ b/build_carddb_lorcana.py
@@ -17,7 +17,6 @@ import psycopg2
 from common import http
 from common.card import CARD_GAME_LORCANA
 from common.config import config
-import build_carddb_mtg
 
 def main():
 	forceRun = '-f' in sys.argv

--- a/build_carddb_lorcana.py
+++ b/build_carddb_lorcana.py
@@ -14,6 +14,7 @@ import zipfile
 
 import psycopg2
 
+from common import http
 from common.card import CARD_GAME_LORCANA
 from common.config import config
 import build_carddb_mtg
@@ -21,7 +22,7 @@ import build_carddb_mtg
 def main():
 	forceRun = '-f' in sys.argv
 
-	was_downloaded = build_carddb_mtg.do_download_file("https://lorcanajson.org/files/current/en/allCards.json.zip", "LorcanaCards.json.zip")
+	was_downloaded = http.download_file("https://lorcanajson.org/files/current/en/allCards.json.zip", "LorcanaCards.json.zip", True)
 	if not was_downloaded and not forceRun:
 		print("No Lorcana card update available, stopping update")
 		return

--- a/build_carddb_lorcana.py
+++ b/build_carddb_lorcana.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""
+This script downloads the latest Disney Lorcana card data from https://lorcanajson.org/ and processes
+it to turn the highly-structured data there into a flat list of card names to descriptions
+formatted to send down the chat.
+"""
+
+import common
+common.FRAMEWORK_ONLY = True
+
+import json
+import sys
+import zipfile
+
+import psycopg2
+
+from common.card import CARD_GAME_LORCANA
+from common.config import config
+import build_carddb_mtg
+
+def main():
+	forceRun = '-f' in sys.argv
+
+	was_downloaded = build_carddb_mtg.do_download_file("https://lorcanajson.org/files/current/en/allCards.json.zip", "LorcanaCards.json.zip")
+	if not was_downloaded and not forceRun:
+		print("No Lorcana card update available, stopping update")
+		return
+
+	print("Loading card data")
+	with zipfile.ZipFile(r"LorcanaCards.json.zip") as card_zip_file:
+		with card_zip_file.open("allCards.json") as cardFile:
+			carddata = json.load(cardFile)
+
+	print("Processing and storing card data")
+	with psycopg2.connect(config['postgres']) as conn, conn.cursor() as cur:
+		cur.execute("DELETE FROM cards WHERE game = %s", (CARD_GAME_LORCANA, ))
+		for card in carddata['cards']:
+			cur.execute("INSERT INTO cards (game, filteredname, name, text, hidden) VALUES (%s, %s, %s, %s, %s)", (
+				CARD_GAME_LORCANA,
+				card['simpleName'],
+				card['fullName'],
+				get_card_description(card),
+				False,
+			))
+	print("Finished updating Lorcana cards")
+
+def get_card_description(card):
+	parts = [f"{card['fullName']} [{card['cost']}, {card['color']}, {'Inkable' if card['inkwell'] else 'Non-inkable'}]"]
+	if card['type'] == "Character":
+		parts.append(f"Character [{card['strength']}/{card['willpower']}]")
+	else:
+		parts.append(card['type'])
+	if 'subtypes' in card:
+		parts.append(", ".join(card['subtypes']))
+	abilities_and_effects_parts = []
+	if 'abilities' in card:
+		abilities_and_effects_parts.extend(card['abilities'])
+	if 'effects' in card:
+		for effect in card['effects']:
+			abilities_and_effects_parts.append(f"{effect['name']} {effect['text']}")
+	if abilities_and_effects_parts:
+		parts.append(" / ".join(abilities_and_effects_parts))
+
+	return " | ".join(parts)
+
+
+if __name__ == "__main__":
+	main()

--- a/build_carddb_lorcana.py
+++ b/build_carddb_lorcana.py
@@ -15,7 +15,7 @@ import zipfile
 import psycopg2
 
 from common import http
-from common.card import CARD_GAME_LORCANA
+from common.card import clean_text, CARD_GAME_LORCANA
 from common.config import config
 
 def main():
@@ -37,7 +37,7 @@ def main():
 		for card in carddata['cards']:
 			cur.execute("INSERT INTO cards (game, filteredname, name, text, hidden) VALUES (%s, %s, %s, %s, %s)", (
 				CARD_GAME_LORCANA,
-				card['simpleName'],
+				clean_text(card['fullName']),
 				card['fullName'],
 				get_card_description(card),
 				False,

--- a/common/card.py
+++ b/common/card.py
@@ -40,6 +40,7 @@ LETTERS_MAP = {
 	'\u00fd': 'y',
 	'\u00fe': 'th',
 	'\u00ff': 'y',
+	'\u0101': 'a',
 }
 
 def clean_text(text):

--- a/common/card.py
+++ b/common/card.py
@@ -5,6 +5,7 @@ from common.postgres import escape_like
 CARD_GAME_MTG = 1
 CARD_GAME_KEYFORGE = 2
 CARD_GAME_PTCG = 3
+CARD_GAME_LORCANA = 4
 
 re_specialchars = re.compile(r"[ \-+'\",:!?.()\u00ae&/\u2019\u201c\u201d\[\]~\u2026\u25b9#\u2014]")
 LETTERS_MAP = {

--- a/lrrbot/commands/card.py
+++ b/lrrbot/commands/card.py
@@ -4,7 +4,7 @@ import lrrbot.decorators
 from lrrbot.main import bot
 import common.postgres
 import common.time
-from common.card import clean_text, CARD_GAME_MTG, CARD_GAME_KEYFORGE, CARD_GAME_PTCG
+from common.card import clean_text, CARD_GAME_MTG, CARD_GAME_KEYFORGE, CARD_GAME_PTCG, CARD_GAME_LORCANA
 
 @bot.command("cardview (on|off)")
 @lrrbot.decorators.mod_only
@@ -54,6 +54,18 @@ def pokemon_card_lookup(lrrbot, conn, event, respond_to, search):
 	Show the details of a given Pokémon TCG card.
 	"""
 	real_card_lookup(lrrbot, conn, event, respond_to, search, game=CARD_GAME_PTCG)
+
+@bot.command("(?:lorcana) (.+)")
+@lrrbot.decorators.throttle(60, count=3)
+def lorcana_card_lookup(lrrbot, conn, event, respond_to, search):
+	"""
+	Command: !lorcana card-name
+	Section: misc
+
+	Show the details of a given Disney Lorcana TCG card.
+	"""
+	real_card_lookup(lrrbot, conn, event, respond_to, search, game=CARD_GAME_LORCANA)
+
 
 def real_card_lookup(lrrbot, conn, event, respond_to, search, noerror=False, includehidden=False, game=CARD_GAME_MTG):
 	cards = find_card(lrrbot, search, includehidden, game)

--- a/www/api_v2.py
+++ b/www/api_v2.py
@@ -168,6 +168,7 @@ CARD_GAME_CODE_MAPPING = {
 	'mtg': 1,
 	'keyforge': 2,
 	'ptcg': 3,
+	'lorcana': 4,
 }
 @blueprint.route("/cardviewer", methods=["POST"])
 @server.csrf.exempt

--- a/www/templates/api_v2_docs.html
+++ b/www/templates/api_v2_docs.html
@@ -62,6 +62,7 @@
 	<dt><code>mtg</code></dt><dd>Magic: The Gathering</dd>
 	<dt><code>keyforge</code></dt><dd>KeyForge</dd>
 	<dt><code>ptcg</code></dt><dd>Pokémon Trading Card Game</dd>
+	<dt><code>lorcana</code></dt><dd>Disney Lorcana Trading Card Game</dd>
 </dl>
 <h4>Examples</h4>
 <pre>{"name": "<a href="http://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=446183">Vigor</a>", "game": "mtg"}</pre>


### PR DESCRIPTION
This adds a build script to add Lorcana cards to the cards database, in the same style as 'build_carddb_mtg'.
It also adds the '!lorcana' command to look up the cards, again in the same way as the other card lookups work.

It doesn't hook the Lorcana data up to the card reader code, because I don't know how that works and didn't want to make too big a pull request.