### PR TITLE
Implement regex searching for show when updated

### DIFF
--- a/lrrbot/stream_status.py
+++ b/lrrbot/stream_status.py
@@ -14,6 +14,7 @@ class StreamStatus:
 
 		self.handle = None
 		self.was_live = None
+		self.old_title = ""
 		self.schedule()
 
 	def reschedule(self):
@@ -33,6 +34,12 @@ class StreamStatus:
 	async def check_stream(self):
 		log.debug("Checking stream")
 		data = await twitch.get_info(use_fallback=False)
+		if self.old_title != data['title']:
+			log.debug("Title changed, parsing for show information")
+			self.old_title = data['title']
+			if self.find_show(self, data['title']):
+				self.show_override = None
+		
 		is_live = bool(data and data['live'])
 		if self.was_live is None:
 			self.was_live = is_live

--- a/lrrbot/stream_status.py
+++ b/lrrbot/stream_status.py
@@ -37,7 +37,7 @@ class StreamStatus:
 		if self.old_title != data['title']:
 			log.debug("Title changed, parsing for show information")
 			self.old_title = data['title']
-			if self.find_show(self, data['title']):
+			if self.lrrbot.find_show(data['title']):
 				self.show_override = None
 		
 		is_live = bool(data and data['live'])

--- a/lrrbot/stream_status.py
+++ b/lrrbot/stream_status.py
@@ -38,7 +38,7 @@ class StreamStatus:
 			log.debug("Title changed, parsing for show information")
 			self.old_title = data['title']
 			if self.lrrbot.find_show(data['title']):
-				self.show_override = None
+				self.lrrbot.override_show(None)
 		
 		is_live = bool(data and data['live'])
 		if self.was_live is None:


### PR DESCRIPTION
Here's some preliminary code to attempt to find a show name from the Twitch title when it's updated.
It uses a new column, "rule" in the shows table to store the RegEx to find the show ID.
It's fairly simple, and I've tried to make it reasonably bulletproof, so if there's 0 or multiple matches it doesn't do anything. It'll also automatically remove an override if the title has changed and a new show has been found.

I've tried to match my code style to what's already there. I've also not tested this on a live instance, as the repo is missing necessary things to do that, like a DB skeleton. This is also the first time I've written Python, so please be gentle. :D